### PR TITLE
Fix evaluator not catching stuck loading states

### DIFF
--- a/agents/evaluator.md
+++ b/agents/evaluator.md
@@ -127,9 +127,14 @@ reaches its final, data-loaded state — not just that it renders an initial she
    evaluate_script(expression: `
      (() => {
        // Detect common loading patterns — adapt to what you find on the page
+       const isActiveLoadingClass = (cls) =>
+         /(^|[\s-])(spinner|loading|skeleton)([\s-]|$)/i.test(cls) &&
+         !/(complete|done|finished|hidden|loaded)/i.test(cls);
        const indicators = [
          ...document.querySelectorAll('[aria-busy="true"]'),
-         ...document.querySelectorAll('[class*="spinner"], [class*="loading"], [class*="skeleton"]'),
+         ...[...document.querySelectorAll('[class]')].filter(el =>
+           isActiveLoadingClass(el.className)
+         ),
          ...[...document.querySelectorAll('*')].filter(el =>
            el.children.length === 0 &&
            /^(loading|please wait)/i.test(el.textContent.trim())

--- a/skills/harness/references/evaluation-guide.md
+++ b/skills/harness/references/evaluation-guide.md
@@ -28,15 +28,27 @@ the page finishes loading. A page stuck on a spinner is BROKEN, not loaded.
 2. take_screenshot()                              → evidence: initial state (may show loading)
 3. evaluate_script(expression: `
      (() => {
+       const isActiveLoadingClass = (cls) =>
+         /(^|[\s-])(spinner|loading|skeleton)([\s-]|$)/i.test(cls) &&
+         !/(complete|done|finished|hidden|loaded)/i.test(cls);
        const indicators = [
          ...document.querySelectorAll('[aria-busy="true"]'),
-         ...document.querySelectorAll('[class*="spinner"], [class*="loading"], [class*="skeleton"]'),
+         ...[...document.querySelectorAll('[class]')].filter(el =>
+           isActiveLoadingClass(el.className)
+         ),
          ...[...document.querySelectorAll('*')].filter(el =>
            el.children.length === 0 &&
            /^(loading|please wait)/i.test(el.textContent.trim())
          )
        ];
-       return { isLoading: indicators.length > 0, count: indicators.length };
+       return {
+         isLoading: indicators.length > 0,
+         indicators: indicators.map(el => ({
+           tag: el.tagName,
+           class: el.className,
+           text: el.textContent.trim().slice(0, 50)
+         }))
+       };
      })()
    `)                                             → detect if page is still loading
 4. // If isLoading is true: wait 10 seconds, then re-run step 3


### PR DESCRIPTION
## Summary
- Evaluator scored pages with infinite spinners as PASS
- "Loading games..." spinner ran forever but wasn't detected as a failure
- Root cause: `wait_for(selector: "body")` passes instantly — body always exists

## What changed

### Evaluator agent
- **Mandatory async content check** after every navigation: wait for real content (list items, cards, rows), not container elements
- **Spinner-absence verification** via `evaluate_script` — checks that no `.spinner`, `.loading`, `[aria-busy=true]` remain
- **Two-screenshot pattern**: initial (may show spinner) + loaded (must show data)
- **10-second timeout**: content never appears → FAIL at 3/10 max
- **Anti-generosity checklist**: two new checks for stuck spinners

### Evaluation guide
- Replaced broken "Basic Page Testing" pattern with async-aware version
- Added "Page with async data loading" scoring calibration: spinner forever = 3/10
- Guidance for timeout diagnosis: check console for failed fetches, CORS, 404/500

## The specific bug this prevents
```
BEFORE: 
  navigate_page → lobby
  wait_for("body") → passes instantly
  take_screenshot → sees "Loading games..." spinner
  score: 7/10 "page loads"  ← WRONG

AFTER:
  navigate_page → lobby  
  take_screenshot → "initial: shows spinner"
  wait_for(".game-card, .list-item") → times out after 10s
  evaluate_script → "1 spinner still active"
  score: 3/10 "broken data flow — spinner never resolves"  ← CORRECT
```