### PR TITLE
Enforce multi-wave Build→Land loop and block premature dk_push

### DIFF
--- a/agents/orchestrator.md
+++ b/agents/orchestrator.md
@@ -94,7 +94,9 @@ Before proceeding, verify:
 **If gate fails** → re-run planner with specific feedback, up to **3 attempts**. If Gate 1
 fails 3 times, halt with an error report explaining which checks failed and why the prompt
 may require manual decomposition. Do NOT proceed.
-**If gate passes** → set `plan = <the plan>`, set `active_units = plan.work_units`. Proceed to Phase 2.
+**If gate passes** → set `plan = <the plan>`, set `active_units = plan.work_units`,
+  set `waves = group_by_wave(active_units)` (ordered list of waves from the dependency graph),
+  set `current_wave = 0`. Proceed to Phase 2.
 
 ---
 
@@ -165,7 +167,7 @@ But if ZERO changesets merged in this wave, that's a hard block.
 **If some merged** → update `merged_commit = <hash>`, record `merge_failures`.
 
 ⚠️ **After landing this wave: DO NOT dk_push. DO NOT ask the user what to do next.**
-If more waves remain → loop back to Phase 2 for the next wave.
+If more waves remain → set `current_wave += 1`, then loop back to Phase 2 for the next wave.
 If all waves are complete → proceed to Phase 4 (Eval).
 
 ---

--- a/skills/dkh/SKILL.md
+++ b/skills/dkh/SKILL.md
@@ -249,7 +249,7 @@ More waves remain → loop back to Build for the next wave.
 All waves complete → proceed to Phase 4 (Eval).
 
 Partial merge failures are tolerable — the evaluator will catch missing functionality.
-Zero merges across all waves is a hard block — re-dispatch.
+Zero merges **in this wave** is a hard block — re-dispatch this wave's generators before advancing.
 
 ### Phase 4: Eval — MANDATORY, NEVER SKIP
 **GATE 3 ENTRY CHECK**: "Did at least one changeset merge? Do I have a commit hash? YES → proceed."


### PR DESCRIPTION
## Summary

- Orchestrator was calling `dk_push` after landing Wave 1 (before eval) and asking the user "What's your preference?" — both harness violations
- Root cause: multi-wave workflow was undefined, so the orchestrator improvised
- Rewrite Phases 2+3 as explicit per-wave Build→Land loop in both SKILL.md and orchestrator.md
- Add gate rule #6: `dk_push` is ONLY allowed in Phase 5 (landing != shipping)
- Add gate rule #7: NEVER ask the user anything
- Add 3-point self-check before every `dk_push` call
- Add wave tracking state (`waves`, `current_wave`, `pushed`)

## Test plan

- [ ] Run `/dkh` with a multi-wave plan — verify no `dk_push` between waves
- [ ] Verify orchestrator proceeds from Wave 1 Land → Wave 2 Build automatically
- [ ] Verify eval runs after all waves are landed, not between waves
- [ ] Verify no user prompts appear during autonomous execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)