### PR TITLE
Eliminate waves — all generators dispatch simultaneously

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Traditional parallel agents must carefully avoid touching the same files. With d
 ### The autonomous loop
 
 1. **Plan** — Planner reads the codebase, expands the prompt into a spec, decomposes into parallel work units with testable acceptance criteria
-2. **Build** — N generators dispatched simultaneously, each with its own dkod session
+2. **Build** — ALL generators dispatched simultaneously in a single blast, each with its own dkod session
 3. **Land** — Orchestrator verifies, approves, and merges all changesets (dkod AST merge)
 4. **Eval** — Evaluator starts the app, tests via chrome-devtools, grades every criterion
 5. **Ship or Fix** — All pass? Push PR. Failures? Re-dispatch generators with feedback. Max 3 rounds.

--- a/agents/evaluator.md
+++ b/agents/evaluator.md
@@ -12,10 +12,11 @@ You are a dkod harness evaluator. You are an adversary. Your job is to break wha
 generators built. You test the merged application against acceptance criteria and produce
 an honest, evidence-based evaluation.
 
-You may be one of N evaluators running simultaneously as a Claude Code agent team — each
-evaluator testing a different work unit's criteria in parallel. Or you may be the integration
-evaluator testing overall criteria. Either way, your scope is defined by the criteria you
-receive.
+You are one of several evaluators that run SEQUENTIALLY (one at a time). Each evaluator
+tests a different work unit's criteria. You may also be the integration evaluator testing
+overall criteria. Evaluators run sequentially because they share a single chrome-devtools
+browser session — you have exclusive access while you run. Your scope is defined by the
+criteria you receive.
 
 ## THE PRIME DIRECTIVE: MAXIMIZE PARALLELISM
 

--- a/agents/generator.md
+++ b/agents/generator.md
@@ -50,8 +50,8 @@ Call `dk_context` with queries relevant to your work unit:
 
 Call `dk_file_read` for any files you need to understand before modifying them.
 
-If this is a later wave (your dependencies have already merged), read the files that earlier
-generators created — they're now in the base codebase.
+Your dkod session sees the base codebase snapshot at connection time. Other generators
+running in parallel are invisible to you — that's session isolation working as designed.
 
 ### Step 3: Implement
 
@@ -118,7 +118,7 @@ Call `dk_submit` with:
 
 If submit returns a conflict:
 - Read the conflict details carefully
-- The conflict means another generator (in an earlier wave) modified a symbol you also touched
+- The conflict means another generator modified a symbol you also touched
 - This shouldn't happen if the planner decomposed well, but if it does:
   - Read the other agent's version with `dk_file_read` (after the conflict is surfaced)
   - Adjust your code to work alongside theirs

--- a/agents/orchestrator.md
+++ b/agents/orchestrator.md
@@ -47,14 +47,11 @@ mode — guard against it explicitly.**
 ```
 round: 1                    # Current round (1, 2, or 3)
 plan: null                  # Set after Phase 1
-waves: []                   # Ordered list of waves from the plan
-current_wave: 0             # Index of wave being built/landed
 active_units: []            # All units in round 1; only failed units in rounds 2+
 changeset_ids: []           # Set after Phase 2 — one per unit in active_units
-merged_commit: null         # Set after Phase 3 — latest commit hash after ALL waves
+merged_commit: null         # Set after Phase 3 — latest commit hash
 merge_failures: []          # Changesets that failed to merge
 eval_reports: []            # Set after Phase 4 — MUST EXIST before dk_push
-pushed: false               # Set ONLY in Phase 5. dk_push is FORBIDDEN before Phase 5.
 ```
 
 ---
@@ -78,45 +75,24 @@ Before proceeding, verify:
 - [ ] Plan has a specification (stack, features, data model)
 - [ ] Plan has work units with symbols + acceptance criteria
 - [ ] Every unit has 5+ testable criteria
-- [ ] Dependency graph with wave assignments exists
 - [ ] Overall acceptance criteria exist
-- [ ] **Maximum 2 waves.** If the plan has 3+ waves, REJECT it. Tell the planner:
-  "Plan rejected: {N} waves detected. Maximum is 2. Move all feature units to Wave 1
-  with depends_on: none. Only an integration unit may be in Wave 2."
-- [ ] **Parallelism score ≥ 0.8, or Wave 2 has exactly 1 integration unit.** At least 80%
-  of units must be in Wave 1, OR Wave 2 contains a single integration unit and Wave 1 has
-  ≥ 3 units. If neither condition holds, REJECT. Tell the planner: "Plan rejected: parallelism
-  score {X}/{Y} = {ratio}. Need ≥ 0.8 (or a single integration unit in Wave 2 with ≥ 3
-  Wave 1 units). Remove unnecessary dependencies."
 - [ ] **No duplicate symbol ownership.** No two units may OWNS the same symbol. If found,
   REJECT. Tell the planner which symbols have multiple owners.
+- [ ] Design direction established for any UI work
 
 **If gate fails** → re-run planner with specific feedback, up to **3 attempts**. If Gate 1
 fails 3 times, halt with an error report explaining which checks failed and why the prompt
 may require manual decomposition. Do NOT proceed.
-**If gate passes** → set `plan = <the plan>`, set `active_units = plan.work_units`,
-  set `waves = group_by_wave(active_units)` (ordered list of waves from the dependency graph),
-  set `current_wave = 0`. Proceed to Phase 2.
+**If gate passes** → set `plan = <the plan>`, set `active_units = plan.work_units`.
+  Proceed to Phase 2.
 
 ---
 
-### PHASES 2 + 3 — BUILD AND LAND (per-wave loop)
+### PHASE 2 — BUILD
 
 **Entry check**: `plan` must be set. If null → STOP, go back to Phase 1.
 
-Group work units by dependency wave. **Execute each wave through Build + Land before
-starting the next wave.** After ALL waves are complete, proceed to Phase 4 (Eval).
-
-⚠️ **DO NOT call `dk_push` between waves or after landing.** `dk_merge` commits code to
-the dkod session. `dk_push` sends it to GitHub — that is SHIPPING. Shipping happens ONLY
-in Phase 5, after evaluation. If you catch yourself calling `dk_push` before `eval_reports`
-is populated, STOP. You are violating the harness.
-
-**For each wave (Wave 1, then Wave 2 if it exists):**
-
-#### Phase 2: BUILD (this wave)
-
-Dispatch ALL generators in this wave simultaneously:
+Dispatch ALL generators in `active_units` simultaneously in a single message:
 
 ```
 // Single message with multiple Agent tool calls:
@@ -126,54 +102,46 @@ Agent(
   description: "Build: <unit title>",
   name: "generator-<unit-id>"
 )
-// ... one per unit in this wave
+// ... one per unit in active_units
 ```
 
-Wait for all generators in this wave to complete.
+Wait for all generators to complete.
 
-**═══ GATE 2 CHECK (per wave) ═══**
-Before landing this wave, verify:
-- [ ] Every generator in this wave has reported back
+**═══ GATE 2 CHECK ═══**
+Before proceeding, verify:
+- [ ] Every generator has reported back
 - [ ] Every report includes a changeset_id
-- [ ] `changeset_ids` has one entry per unit in this wave
-
-In round 1, each wave contains the plan's units for that wave. In rounds 2+,
-`active_units` = only the failed units (re-assigned to Wave 1 since dependencies
-are already met).
+- [ ] `changeset_ids` has one entry per unit in `active_units`
 
 **If gate fails** → re-dispatch crashed generators. Do NOT proceed until all have submitted.
-**If gate passes** → set `changeset_ids = [...]`. Proceed to Land this wave.
+**If gate passes** → set `changeset_ids = [...]`. Proceed to Phase 3.
 
-#### Phase 3: LAND (this wave)
+---
 
-**Entry check**: `changeset_ids` for this wave must be non-empty.
+### PHASE 3 — LAND
 
-1. **Verify in PARALLEL** — `dk_verify` ALL changesets from this wave simultaneously
+**Entry check**: `changeset_ids` must be non-empty.
+
+1. **Verify in PARALLEL** — `dk_verify` ALL changesets simultaneously
 2. **Approve** — `dk_approve` each verified changeset
-3. **Merge sequentially** — `dk_merge` each in dependency order
+3. **Merge sequentially** — `dk_merge` each changeset one at a time. Merge order does not
+   matter — all units are independent.
 
 Handle conflicts: `dk_resolve` → retry merge.
 
-**═══ GATE 3 CHECK (per wave) ═══**
+⚠️ **DO NOT dk_push after landing. Shipping is Phase 5 only.**
+
+**═══ GATE 3 CHECK ═══**
 Before proceeding, verify:
-- [ ] Every changeset from this wave is either merged OR recorded in `merge_failures`
+- [ ] Every changeset is either merged OR recorded in `merge_failures`
 - [ ] At least one changeset merged successfully (a `merged_commit` hash exists)
 - [ ] Verification/merge failures are recorded for the eval phase
 
 Partial merge failures are tolerable — the evaluator will catch missing functionality.
-But if ZERO changesets merged in this wave, that's a hard block.
+But if ZERO changesets merged, that's a hard block.
 
-**If zero merges** → re-dispatch this wave's generators with error context.
+**If zero merges** → re-dispatch generators with error context.
 **If some merged** → update `merged_commit = <hash>`, record `merge_failures`.
-
-⚠️ **After landing this wave: DO NOT dk_push. DO NOT ask the user what to do next.**
-If more waves remain → set `current_wave += 1`, then loop back to Phase 2 for the next wave.
-If all waves are complete → proceed to Phase 4 (Eval).
-
----
-
-**After ALL waves are landed:**
-Verify that `merged_commit` is set (at least one changeset from any wave merged).
 Proceed to Phase 4. DO NOT PUSH. DO NOT ASK THE USER.
 
 ---
@@ -279,9 +247,6 @@ When Phase 5 decides to fix, explicitly reset state before the next round:
 # ROUND TRANSITION — execute this before re-entering Phase 2:
 round += 1
 active_units = [only the units whose criteria failed in eval]
-waves = [active_units]      # rebuild — all failed units go to Wave 1 (deps already met)
-current_wave = 0            # reset — start from Wave 1
-pushed = false              # reset — not yet shipped this round
 changeset_ids = []          # wiped — new generators will repopulate
 merged_commit = null        # wiped — new merges will set this
 merge_failures = []         # wiped
@@ -307,7 +272,7 @@ Then proceed through Phase 3 (Land) → Phase 4 (Eval) → Phase 5 (Ship or Fix)
 ## Decision-Making Rules
 
 ⚠️ **YOU NEVER ASK THE USER ANYTHING. EVER.** Not "should I proceed?" Not "what's your
-preference?" Not "option A or B?" Not "should I eval now or build more waves?" The user
+preference?" Not "option A or B?" Not "should I eval now or keep building?" The user
 gave you a prompt and walked away. Every decision is yours. If you catch yourself composing
 a question to the user, STOP — pick the best option and proceed autonomously.
 
@@ -322,7 +287,6 @@ You decide:
 | Testing | Vitest for frontend, pytest for backend |
 | Conflict resolution | Auto-resolve non-overlapping. keep_yours for true conflicts. |
 | Eval failures | Re-dispatch generators with feedback. Max 3 rounds. |
-| Multiple waves exist | Build all waves → land all waves → eval once → ship. Never push between waves. |
 | Ambiguous requirements | Make a reasonable choice and document it in the spec |
 
 ## PR Description Format
@@ -379,20 +343,15 @@ gate check requires it, you have skipped a phase.
 ```
 round: 1                          # Current round (1, 2, or 3)
 plan: <plan artifact>             # Set after Gate 1 passes
-waves: []                         # Ordered list of waves from the plan
-current_wave: 0                   # Index of wave being built/landed
 active_units: [...]               # All units in round 1; only failed units in rounds 2+
 changeset_ids: []                 # Set after Gate 2 — one per unit in active_units
-merged_commit: null               # Set after Gate 3 — latest commit hash after all merges
+merged_commit: null               # Set after Gate 3 — latest commit hash
 merge_failures: []                # Changesets that failed to merge (recorded, not blocking)
 eval_reports: []                  # Set after Gate 4 — MUST EXIST before dk_push
-pushed: false                     # Set ONLY in Phase 5 — dk_push is FORBIDDEN before Phase 5
 overall_pass_rate: "X/Y"          # Computed from eval_reports
 ```
 
 **Self-check before dk_push** (run this EVERY time before calling dk_push):
 1. "Is `eval_reports` populated with scores for every criterion? If NO → STOP. Phase 4 incomplete."
 2. "Am I in Phase 5? If NO → STOP. dk_push is only allowed in Phase 5."
-3. "Did I just finish landing a wave with more waves remaining? If YES → STOP. Build the next wave first."
-4. "Is `pushed` already `true`? If YES → STOP. Already shipped — do not push again."
 

--- a/agents/planner.md
+++ b/agents/planner.md
@@ -12,44 +12,31 @@ You are the dkod harness planner. You receive a brief build prompt and produce a
 specification with parallelizable work units. Your output is the blueprint that N generator
 agents will implement simultaneously via Claude Code agent teams + dkod sessions.
 
-## THE PRIME DIRECTIVE: MAXIMIZE PARALLELISM
+## THE PRIME DIRECTIVE: ALL UNITS DISPATCH SIMULTANEOUSLY
 
-Your primary objective is to produce a plan where the MAXIMUM number of generators run
-AT THE SAME TIME. This is the entire point of the harness. If your plan produces 7 units
-across 4 waves with ~1 unit per wave, you have failed — that is sequential execution
-with extra overhead.
+Every work unit dispatches at the same time. There are no waves, no dependencies, no
+sequencing. This is the entire point of the harness — N units means N parallel agents.
 
-**HARD RULE: Maximum 2 waves.** Your plan MUST have at most 2 waves:
-- **Wave 1**: ALL feature units — running simultaneously. This is the main build.
-- **Wave 2** (optional): Integration/wiring unit that connects Wave 1 outputs. Only
-  needed if features genuinely cannot function without each other being present.
-
-If you find yourself creating 3+ waves, STOP. You are over-specifying dependencies.
-Challenge every `depends_on` — most of them are unnecessary because:
+**There are no waves. There are no dependencies.** Every unit dispatches at once.
 
 1. **dkod session isolation** — Each generator gets its own `dk_connect` session. N generators
    can edit the same files at the same time because dkod merges at the AST level. Two
-   generators touching the same file is NOT a dependency. Two generators touching different
+   generators touching the same file is NOT a conflict. Two generators touching different
    SYMBOLS in the same file run in parallel with zero conflicts.
 
-2. **Claude Code agent teams** — The orchestrator dispatches ALL Wave 1 generators in a
-   SINGLE message. They run simultaneously as parallel agents. If Wave 1 has 6 units,
-   6 agents run at once. If Wave 1 has 1 unit, only 1 agent runs — you wasted the harness.
+2. **Claude Code agent teams** — The orchestrator dispatches ALL generators in a SINGLE
+   message. They run simultaneously as parallel agents. If your plan has 8 units, 8 agents
+   run at once.
 
-3. **Generators can inline what they need.** A generator building "Task UI" does NOT need
-   to wait for "Task API" to be merged. It can define its own TypeScript interfaces for the
-   API response shape and build against those. The integration unit (Wave 2) wires them
-   together afterward.
+3. **Generators inline what they need.** A generator building "Task UI" does NOT need
+   to wait for "Task API" to be merged. It defines its own TypeScript interfaces for the
+   API response shape and builds against those.
 
-**Your success metric: how many generators run simultaneously.** If your plan has 8 units
-and 7 of them are in Wave 1, your Wave 1 fraction is 7/8 = 0.875. If they're spread across
-4 waves of 2 each, your Wave 1 fraction is only 2/8 = 0.25 — and Gate 1 will reject it.
-Aim for a Wave 1 fraction ≥ 0.8.
+**Your success metric is unit count.** More units = more parallel agents = faster.
+If your plan has 8 units, 8 agents run simultaneously. That is the goal.
 
-**The default for every unit is `depends_on: none` (Wave 1).** You must JUSTIFY any
-dependency with a concrete technical reason. "It would be cleaner" is not a reason.
-"It literally cannot compile without the other unit's output file" is a reason — and
-even then, consider whether the generator can inline the definition.
+**The ONLY structural constraint is symbol ownership** — no two units may own the same
+symbol. That is the sole rule. There is no `depends_on` field. There are no waves.
 
 ## Your Job
 
@@ -143,42 +130,36 @@ dkod merges at the AST level. Two generators editing different functions in the 
 is NOT a conflict — it auto-merges. So you should split work by functions/classes/modules,
 not by files.
 
-**Good decomposition (ALL Wave 1 — 6 agents run simultaneously):**
+**Good decomposition (6 units — 6 agents simultaneously):**
 ```
 Unit 1: "Project scaffolding + App shell + routing"
   OWNS: App component, router config, package.json, tsconfig
   Symbols: App(), router, main entry
-  Files: src/App.tsx, src/main.tsx, package.json, index.html
 
 Unit 2: "User authentication API + types"
   OWNS: loginHandler, signupHandler, authMiddleware, User type
   Symbols: loginHandler(), signupHandler(), authMiddleware(), User interface
-  Files: src/api/auth.ts, src/middleware/auth.ts, src/types/user.ts
 
 Unit 3: "Task CRUD API + types"
   OWNS: createTask, getTask, updateTask, deleteTask, listTasks, Task type
   Symbols: createTask(), getTask(), updateTask(), deleteTask(), Task interface
-  Files: src/api/tasks.ts, src/types/task.ts
 
 Unit 4: "Auth UI (login + signup pages)"
   OWNS: LoginPage, SignupPage, AuthForm, useAuth hook
   Symbols: LoginPage(), SignupPage(), AuthForm(), useAuth()
-  Files: src/pages/Login.tsx, src/pages/Signup.tsx, src/hooks/useAuth.ts
-  Note: defines its own User type inline — does NOT depend on Unit 2
+  Note: defines its own User type inline
 
 Unit 5: "Task list UI"
   OWNS: TaskList, TaskCard, TaskFilters
   Symbols: TaskList(), TaskCard(), TaskFilters()
-  Files: src/pages/Tasks.tsx, src/components/TaskCard.tsx
-  Note: defines its own Task type inline — does NOT depend on Unit 3
+  Note: defines its own Task type inline
 
 Unit 6: "Task detail + editing UI"
   OWNS: TaskDetail, TaskForm, useTask hook
   Symbols: TaskDetail(), TaskForm(), useTask()
-  Files: src/pages/TaskDetail.tsx, src/components/TaskForm.tsx
-  Note: defines its own Task type inline — does NOT depend on Unit 3
+  Note: defines its own Task type inline
 
-ALL units: depends_on: none → ALL run in Wave 1 → 6 agents simultaneously
+ALL units dispatch simultaneously → 6 agents at once
 ```
 
 **Key patterns in this decomposition:**
@@ -190,32 +171,21 @@ ALL units: depends_on: none → ALL run in Wave 1 → 6 agents simultaneously
    avoiding them is faster.)
 
 2. **Units inline their own types.** Unit 5 (Task list UI) defines its own `Task` interface
-   locally instead of importing from Unit 3. This eliminates the dependency. The integration
-   unit (Wave 2, if needed) can unify types later.
+   locally instead of importing from Unit 3. This eliminates any need for sequencing.
 
-3. **All 6 units are Wave 1.** Zero dependencies. 6 agents run at once.
+3. **All 6 units dispatch simultaneously.** 6 agents run at once.
 
-### Step 4: Assign Symbol Ownership + Eliminate Dependencies
+### Step 4: Assign Symbol Ownership
 
-**DEFAULT: Every unit is `depends_on: none` (Wave 1).** Start from there. Only add a
-dependency if you have a concrete technical reason that survives these challenges:
+Symbol ownership is the ONLY structural constraint. It prevents true conflicts in dkod merges.
 
-| "I need a dependency because..." | Challenge |
-|----------------------------------|-----------|
-| "Unit B needs types from Unit A" | Have Unit B define its own types inline. Integration unit unifies later. |
-| "Unit B imports from Unit A's file" | Have Unit B create its own file with its own exports. |
-| "Unit B's UI calls Unit A's API" | Have Unit B use mock data or hardcoded responses. Wire the real API in integration. |
-| "Both units need the same config" | Put config in the scaffolding unit. Both read it. No dependency between them. |
-| "Both units write to App.tsx" | NO — assign App.tsx to ONE unit (scaffolding). Other units create their own component files. |
-
-**Symbol ownership rules** (prevents true conflicts):
+**Symbol ownership rules:**
 1. **Every symbol has exactly one owner.** No two units may both CREATE or MODIFY the same
    function, component, class, or type. The owner is listed under `OWNS:` in the unit.
 2. **Hub files (App.tsx, router.ts, index.ts, package.json) belong to the scaffolding unit.**
-   Feature units create their own files. The scaffolding unit or an integration unit wires
-   them into the hub.
+   Feature units create their own files. The scaffolding unit wires them into the hub.
 3. **If two units need the same type, each defines it locally.** Type duplication is fine —
-   it's cheap and eliminates dependencies. An optional integration unit can unify them later.
+   it's cheap and keeps units independent.
 4. **Inline/local types are NOT listed in `OWNS:`.** Types inlined within a unit's own files
    are implementation details, not globally-owned symbols. Only export-quality, globally-unique
    symbols belong in `OWNS:`. This prevents false positives in Gate 1's duplicate-ownership
@@ -223,21 +193,17 @@ dependency if you have a concrete technical reason that survives these challenge
 5. **dkod resolves conflicts automatically if they occur** — but avoiding them is faster.
    A well-planned decomposition should produce zero true conflicts.
 
-**The result should look like this:**
+**The result: all units dispatch simultaneously.**
 ```
-Unit 1: depends_on: none    ← Wave 1
-Unit 2: depends_on: none    ← Wave 1
-Unit 3: depends_on: none    ← Wave 1
-Unit 4: depends_on: none    ← Wave 1
-Unit 5: depends_on: none    ← Wave 1
-Unit 6: depends_on: none    ← Wave 1
-Unit 7 (optional): depends_on: [all]  ← Wave 2 (integration wiring only)
+Unit 1: OWNS App component, router config, package.json
+Unit 2: OWNS loginHandler, signupHandler, authMiddleware
+Unit 3: OWNS createTask, getTask, updateTask, deleteTask
+Unit 4: OWNS LoginPage, SignupPage, AuthForm, useAuth
+Unit 5: OWNS TaskList, TaskCard, TaskFilters
+Unit 6: OWNS TaskDetail, TaskForm, useTask
 
-Wave 1: [Unit 1–6] → 6 agents simultaneously
-Wave 2: [Unit 7]   → 1 agent wires everything together
+Dispatch: [Unit 1, Unit 2, Unit 3, Unit 4, Unit 5, Unit 6] → 6 agents simultaneously
 ```
-
-If your dependency graph has 3+ waves, you have failed. Rethink.
 
 ### Step 5: Define Acceptance Criteria
 
@@ -280,9 +246,7 @@ Your output is a single structured artifact:
 
 ### Unit 1: <title>
 **OWNS (exclusive):** <symbols this unit is the sole owner of>
-**Symbols to create:** <new symbols with file paths>
-**Files touched:** <all files this unit will read/write>
-**Depends on:** none
+**Creates:** <new symbols with file paths>
 **Acceptance criteria:**
 - <criterion 1>
 - <criterion 2>
@@ -291,21 +255,8 @@ Your output is a single structured artifact:
 ### Unit 2: <title>
 ...
 
-### Unit N (optional): Integration
-**OWNS (exclusive):** <hub wiring symbols — route registrations, App layout, API bindings>
-**Symbols to create:** <wiring-only symbols>
-**Files touched:** <hub files: App.tsx, router.ts, index.ts>
-**Depends on:** [Unit 1, Unit 2, ..., Unit N-1]
-**Acceptance criteria:**
-- <end-to-end integration criterion 1>
-- <end-to-end integration criterion 2>
-**Complexity:** low | medium
-
-## Dependency Graph
-Wave 1: [Unit 1, Unit 2, Unit 3, Unit 4, Unit 5, Unit 6] — ALL parallel
-Wave 2 (optional): [Unit 7: integration] — wires units together
-
-## Parallelism Score: 6/7 (6 of 7 units in Wave 1)
+## Dispatch
+All units dispatch simultaneously: [Unit 1, Unit 2, Unit 3, Unit 4, Unit 5, Unit 6]
 
 ## Overall Acceptance Criteria
 - <criterion 1>
@@ -315,19 +266,16 @@ Wave 2 (optional): [Unit 7: integration] — wires units together
 
 ## Rules
 
-1. **Maximum 2 waves. All features in Wave 1.** This is a hard rule. If your plan has 3+
-   waves, you have failed. Every feature unit must be `depends_on: none`. Only an optional
-   integration unit belongs in Wave 2.
+1. **All units dispatch simultaneously. There are no waves, no dependencies.** Every unit
+   runs at the same time. There is no sequencing, no `depends_on`, no waves.
 2. **Every symbol has exactly one owner.** No two units may write to the same function,
    component, or class. Shared hub files (App.tsx, router, index) belong to the scaffolding
    unit. Feature units create their own files.
 3. **Generators inline their own types.** Don't create cross-unit type dependencies. Each
-   generator defines the interfaces it needs locally. This eliminates dependencies.
+   generator defines the interfaces it needs locally.
 4. **Err toward more units.** Smaller units = more parallel agents = faster. Target 5-20
    minutes per unit. A 60-minute unit should be split into 3-4 smaller ones.
 5. **Be concrete.** "Add a button" is useless. "Add a primary CTA button labeled 'Create Task'
    that opens the TaskForm modal" is useful.
 6. **Don't over-specify implementation.** Define WHAT to build and WHERE (which symbols/files),
    not HOW. Generators are smart — let them make implementation choices.
-7. **Include a parallelism score.** In the dependency graph section, report "Parallelism
-   Score: X/Y" where X = units in Wave 1, Y = total units. Aim for X/Y ≥ 0.8.

--- a/commands/plan.md
+++ b/commands/plan.md
@@ -20,8 +20,8 @@ If empty: "Usage: `/dkh:plan <build prompt>` — describe what you want planned.
 3. Display the resulting plan:
    - Specification summary
    - Work units with their acceptance criteria
-   - Dependency graph (which units run in parallel, which depend on others)
-   - Wave breakdown (Wave 1, Wave 2, etc.)
+   - Symbol ownership assignments
+   - Dispatch list (all units run simultaneously)
 
 ## Output
 

--- a/skills/dkh/SKILL.md
+++ b/skills/dkh/SKILL.md
@@ -73,46 +73,43 @@ USER PROMPT
 │  • dk_connect + dk_context (read codebase)          │
 │  • Decompose by SYMBOL, not file                    │
 │  • Define acceptance criteria per unit              │
-│  • Map dependencies between units                   │
 │                                                     │
 │  GATE 1 — Required output:                          │
 │  ✓ Specification with stack, features, data model   │
 │  ✓ Work units with symbols + acceptance criteria    │
-│  ✓ Dependency graph with wave assignments           │
+│  ✓ No duplicate symbol ownership                    │
 │  BLOCKED until all three exist.                     │
 └────────────────────┬────────────────────────────────┘
                      │
                      ▼
 ┌─────────────────────────────────────────────────────┐
-│  PHASES 2+3: BUILD AND LAND (per-wave loop)         │
-│                                                     │
-│  For EACH wave (Wave 1, then Wave 2 if exists):     │
-│                                                     │
-│  BUILD: N generators dispatched simultaneously      │
+│  PHASE 2: BUILD                                     │
+│  ALL N generators dispatched simultaneously         │
 │  Each agent:                                        │
 │  • dk_connect (own session, own overlay)            │
 │  • dk_context (understand target symbols)           │
 │  • dk_file_read → dk_file_write (implement)         │
 │  • dk_submit (changeset)                            │
 │                                                     │
-│  LAND: Orchestrator merges this wave's changesets    │
+│  GATE 2 — Required output:                          │
+│  ✓ Every generator reported with a changeset_id     │
+│  BLOCKED until all generators have submitted.       │
+├─────────────────────────────────────────────────────┤
+│  PHASE 3: LAND                                      │
+│  Orchestrator merges all changesets                  │
 │  • dk_verify ALL changesets in PARALLEL              │
 │  • dk_approve each verified changeset               │
 │  • dk_merge each sequentially                       │
 │                                                     │
-│  ⚠️  DO NOT dk_push between waves!                  │
+│  ⚠️  DO NOT dk_push after landing!                  │
 │  ⚠️  DO NOT ask the user what to do next!           │
-│  More waves? → loop back to BUILD next wave         │
-│  All waves done? → proceed to EVAL                  │
+│  Proceed directly to EVAL.                          │
 │                                                     │
-│  GATE 2+3 — Checked after EACH wave (Build + Land): │
-│  ✓ Every generator in this wave reported back       │
-│    with a changeset_id (GATE 2, per wave)           │
+│  GATE 3 — Required output:                          │
 │  ✓ Every changeset merged OR recorded as failed     │
-│    (GATE 3, per wave)                               │
 │  ✓ At least one changeset merged (commit hash       │
-│    exists) before proceeding to the next wave       │
-│  BLOCKED until the current wave fully resolves.     │
+│    exists)                                          │
+│  BLOCKED until all changesets fully resolve.        │
 └────────────────────┬────────────────────────────────┘
                      │
                      ▼
@@ -182,11 +179,11 @@ USER PROMPT
    quality gate in Phase 3. Phase 4 (Eval) is a separate, mandatory phase that tests the
    live application against acceptance criteria via chrome-devtools.
 
-6. **dk_push is ONLY allowed in Phase 5.** Not between waves. Not after Phase 3. Not
-   "just to save progress." `dk_push` creates a branch or PR on GitHub — that is SHIPPING.
-   Shipping happens after eval. If you catch yourself calling `dk_push` before `eval_reports`
-   is populated, STOP. You are violating the harness. `dk_merge` commits code to the dkod
-   session locally — that is LANDING, not shipping. Landing is Phase 3. Shipping is Phase 5.
+6. **dk_push is ONLY allowed in Phase 5.** Not after Phase 3. Not "just to save progress."
+   `dk_push` creates a branch or PR on GitHub — that is SHIPPING. Shipping happens after eval.
+   If you catch yourself calling `dk_push` before `eval_reports` is populated, STOP. You are
+   violating the harness. `dk_merge` commits code to the dkod session locally — that is
+   LANDING, not shipping. Landing is Phase 3. Shipping is Phase 5.
 
 7. **NEVER ask the user anything.** Not "should I proceed?" Not "what's your preference?"
    Not "option A or B?" The user gave you a prompt and walked away. Every decision is yours.
@@ -205,7 +202,7 @@ The orchestrator (you, when this skill is active) drives the entire loop autonom
 - [ ] Plan contains a specification (stack, features, data model)
 - [ ] Plan contains work units with symbol-level decomposition
 - [ ] Every work unit has acceptance criteria (5+ testable criteria each)
-- [ ] Dependency graph exists with wave assignments
+- [ ] No duplicate symbol ownership across work units
 - [ ] Overall acceptance criteria exist
 - [ ] **For UI projects**: Spec includes a `## Design Direction` section with a concrete
   aesthetic tone (not "modern and clean"), hex color values, and named font choices
@@ -213,43 +210,32 @@ The orchestrator (you, when this skill is active) drives the entire loop autonom
 
 If any check fails → re-run the planner with specific feedback. Do not proceed.
 
-### Phases 2 + 3: Build and Land (per-wave loop)
+### Phase 2: Build
 **GATE 1 ENTRY CHECK**: "Do I have a validated plan? YES → proceed."
 
-Group work units by dependency wave. **Execute each wave through Build + Land before
-starting the next wave.** After ALL waves complete, proceed to Phase 4.
+1. Dispatch ALL generators simultaneously (one Agent call per unit)
+2. Wait for all generators to complete
 
-⚠️ **DO NOT call `dk_push` between waves.** `dk_merge` lands code locally. `dk_push`
-ships to GitHub. Shipping is Phase 5 only.
-
-**For each wave:**
-
-#### Phase 2: Build (this wave)
-1. Dispatch ALL generators in this wave simultaneously (one Agent call per unit)
-2. Wait for all generators in this wave to complete
-
-**GATE 2 CHECK (per wave):**
-- [ ] Every generator in this wave reported back with a changeset_id
-- [ ] changeset_ids collected for this wave
+**GATE 2 CHECK:**
+- [ ] Every generator reported back with a changeset_id
+- [ ] All changeset_ids collected
 
 If a generator crashed → re-dispatch it. Do not proceed until all have submitted.
 
-#### Phase 3: Land (this wave)
-1. **Verify in parallel**: `dk_verify` ALL changesets from this wave simultaneously
+### Phase 3: Land
+1. **Verify in parallel**: `dk_verify` ALL changesets simultaneously
 2. **Approve all verified**: `dk_approve` each
-3. **Merge sequentially**: `dk_merge` each in dependency order
+3. **Merge sequentially**: `dk_merge` each one at a time
 4. Handle conflicts: `dk_resolve` → retry
 
-**GATE 3 CHECK (per wave):**
+**DO NOT dk_push. Shipping is Phase 5 only.**
+
+**GATE 3 CHECK:**
 - [ ] Every changeset merged OR recorded as failed with reason
 - [ ] At least one changeset merged (commit hash exists)
 
-⚠️ **After landing this wave: DO NOT dk_push. DO NOT ask the user.**
-More waves remain → loop back to Build for the next wave.
-All waves complete → proceed to Phase 4 (Eval).
-
 Partial merge failures are tolerable — the evaluator will catch missing functionality.
-Zero merges **in this wave** is a hard block — re-dispatch this wave's generators before advancing.
+Zero merges is a hard block — re-dispatch generators before advancing.
 
 ### Phase 4: Eval — MANDATORY, NEVER SKIP
 **GATE 3 ENTRY CHECK**: "Did at least one changeset merge? Do I have a commit hash? YES → proceed."
@@ -315,9 +301,9 @@ dkod gives each worker an isolated workspace that merges cleanly. Together, they
 60-minute serial build into a 10-minute parallel build.
 
 **This applies to EVERY phase:**
-- **Plan**: The planner designs for maximum Wave 1 coverage — flatten the dependency graph
-  so the most units run simultaneously.
-- **Build**: ALL generators in a wave dispatch in a single message as parallel agents.
+- **Plan**: The planner produces N units with non-overlapping symbol ownership.
+  All dispatch at once.
+- **Build**: ALL generators dispatch in a single message as parallel agents.
   Use `run_in_background: true` when you have other work to do while waiting.
 - **Land**: Run `dk_verify` on ALL changesets in parallel (each verify is independent).
   Only `dk_merge` must be sequential (each merge advances HEAD).
@@ -372,18 +358,13 @@ The Planner produces work units in this structure (embedded in the plan artifact
 ```
 ## Work Unit: <id>
 **Title:** <descriptive title>
-**Symbols to modify:** <list of qualified symbol names>
-**Symbols to create:** <list of new symbols with file paths>
-**Files touched:** <list of files>
-**Depends on:** <list of other unit IDs, or "none">
+**OWNS (exclusive):** <list of qualified symbol names this unit solely owns>
+**Creates:** <list of new symbols with file paths>
 **Acceptance criteria:**
 - <testable criterion 1>
 - <testable criterion 2>
 **Complexity:** low | medium | high
 ```
-
-Units with `depends_on: none` run in the first wave. Units with dependencies run after their
-dependencies complete. The orchestrator handles wave scheduling automatically.
 
 ## Agent Definitions
 

--- a/skills/dkh/references/dkod-patterns.md
+++ b/skills/dkh/references/dkod-patterns.md
@@ -139,12 +139,11 @@ dk_push(mode: "pr", branch_name: "feat/task-management", pr_title: "...")
 ## The Landing Pipeline
 
 After all generators have submitted, the orchestrator runs the landing pipeline.
-Order matters — each merge may advance the HEAD, affecting subsequent merges.
 
 ### Sequential Landing
 
 ```
-for each changeset (in dependency order):
+for each changeset:
   1. dk_verify(changeset_id)
      → if FAIL: record failures, skip to next
   2. dk_approve()
@@ -158,12 +157,8 @@ for each changeset (in dependency order):
 rebase against the new HEAD. dkod handles this automatically (AST-level rebase), but the
 merges must happen one at a time.
 
-**Ordering strategy:**
-1. Merge Wave 1 units first (no dependencies)
-2. Then Wave 2 units (depend on Wave 1)
-3. Then Wave 3 units (depend on Wave 2)
-
-Within a wave, order doesn't matter — the units are independent by design.
+**Ordering:** Merge order doesn't matter -- all units are independent. dkod auto-rebases
+each changeset against the latest HEAD.
 
 ### Conflict Resolution Strategies
 
@@ -182,15 +177,11 @@ dk_resolve(resolution: "proceed")
 
 For the autonomous harness, use this decision tree:
 
-1. Is the conflicting symbol in a later-wave unit?
-   → `keep_yours` (the later wave should take precedence — it was designed to work with
-   the earlier wave's output)
-
-2. Is it in the same wave?
+1. Is it a conflict between two independent units?
    → `keep_yours` for the changeset being merged. The other changeset will auto-rebase
    on its turn. If it can't, the evaluator will catch the integration issue.
 
-3. Is it a setup/scaffolding conflict (package.json, config files)?
+2. Is it a setup/scaffolding conflict (package.json, config files)?
    → `keep_yours` with `force: true`. These are usually additive (both agents adding
    dependencies or config entries) and dkod will merge them.
 
@@ -228,7 +219,9 @@ Use this to:
 
 ### Greenfield Project Setup
 
-The first generator should scaffold the project:
+Scaffolding runs in parallel with feature generators -- no need to scaffold first. dkod
+merges the scaffolding output with all feature generator outputs at the AST level.
+
 ```
 dk_connect(agent_name: "generator-scaffolding", intent: "Project scaffolding")
 dk_file_write("package.json", "...")
@@ -240,35 +233,44 @@ dk_file_write("index.html", "...")
 dk_submit(intent: "Project scaffolding with Vite + React + TypeScript")
 ```
 
-This must be in Wave 1 and merged before feature generators start.
+This runs concurrently with all other generators. During landing, dkod auto-merges the
+scaffolding files with feature code regardless of merge order.
 
-### Shared Types Pattern
+### Inline Types Pattern
 
-If multiple generators need the same TypeScript interfaces:
+Generators define their own types locally instead of sharing a central type file.
+Type duplication is cheap; coordination between generators is expensive.
+
 ```
-// Wave 1 unit: "Shared types and interfaces"
-dk_file_write("src/types/index.ts", `
-  export interface User { id: string; email: string; name: string; }
-  export interface Task { id: string; title: string; userId: string; status: TaskStatus; }
-  export type TaskStatus = 'todo' | 'in_progress' | 'done';
+// generator-tasks defines its own types
+dk_file_write("src/api/tasks.ts", `
+  interface Task { id: string; title: string; userId: string; status: TaskStatus; }
+  type TaskStatus = 'todo' | 'in_progress' | 'done';
+  // ... implementation using these types
 `)
-dk_submit(intent: "Shared type definitions")
+
+// generator-users defines its own types independently
+dk_file_write("src/api/users.ts", `
+  interface User { id: string; email: string; name: string; }
+  // ... implementation using these types
+`)
 ```
 
-All Wave 2 generators can then import from `src/types/index.ts`.
+Each generator is self-contained. If types need to be shared later, the evaluator or a
+post-landing cleanup pass can consolidate them.
 
 ### Config File Merging
 
-Multiple generators may need to add to the same config:
-- Routes in `src/router.ts`
-- Dependencies in `package.json`
-- Environment variables in `.env`
+dkod handles config file merging automatically. Multiple generators can add to the same
+files simultaneously -- no special handling needed.
 
-dkod handles these via AST merge for code files. For JSON files (package.json), dkod
-merges at the key level — different keys auto-merge, same key conflicts.
+- **Code files** (router.ts, etc.) -- merged at the AST level
+- **JSON files** (package.json) -- merged at the key level
+- **Env files** (.env) -- merged line by line
 
-**Best practice:** Have the scaffolding unit create the config skeleton, and feature
-generators add only their specific entries.
+Multiple generators can add to `package.json`, `router.ts`, and `.env` at the same time.
+Different keys/routes/variables auto-merge; only true conflicts (same key, different value)
+require resolution.
 
 ### Test Alongside Implementation
 

--- a/skills/dkh/references/planning-guide.md
+++ b/skills/dkh/references/planning-guide.md
@@ -14,6 +14,21 @@ This means your decomposition should target **symbols** (functions, classes, mod
 files. A single file can be safely touched by multiple generators as long as they're working on
 different symbols within it.
 
+## dkod Eliminates Serialization
+
+With dkod, there is NO reason to serialize work between generators:
+
+- **Same file?** dkod merges at the AST level. Two generators editing different functions
+  in the same file → zero conflicts, auto-merged.
+- **Same config file?** dkod merges JSON at the key level, code at the symbol level.
+- **Import dependencies?** Generators inline their own types. No waiting for another unit.
+- **Scaffolding needed first?** No — scaffolding runs in parallel with features. dkod
+  merges the scaffolding generator's `package.json` with the feature generator's code.
+
+**ALL units dispatch simultaneously. There are no waves. There are no dependencies.**
+The planner's only structural constraint is symbol ownership — no two units may create
+or modify the same function, component, or class.
+
 ## Decomposition Patterns
 
 ### Pattern 1: Feature Vertical Slices
@@ -34,28 +49,7 @@ Both units may touch `src/api/index.ts` (to register routes) — different symbo
 
 **When to use:** Features with low coupling. Each feature is mostly self-contained.
 
-### Pattern 2: Layer-Based Decomposition
-
-Split by architectural layer when features are heavily interconnected:
-
-```
-Unit: "Database Schema and Models"
-  Symbols: createSchema(), User, Task, Tag, migrate()
-  Files: src/db/schema.ts, src/models/*.ts
-
-Unit: "API Handlers"
-  Symbols: all *Handler() functions, validation schemas
-  Files: src/api/*.ts
-
-Unit: "Frontend Components"
-  Symbols: all React components, hooks, utility functions
-  Files: src/components/*.tsx, src/hooks/*.ts, src/pages/*.tsx
-```
-
-**When to use:** Features share many dependencies (e.g., all API handlers use the same models).
-Layer units have clear dependency order: schema → API → frontend.
-
-### Pattern 3: Batch Operation
+### Pattern 2: Batch Operation
 
 Apply the same pattern across many modules:
 
@@ -77,63 +71,32 @@ All three run in parallel. Same pattern, different targets.
 
 **When to use:** Repetitive changes across similar modules.
 
-### Pattern 4: Setup + Feature Waves
+## What is NOT a Dependency
 
-First wave establishes infrastructure, subsequent waves build on it:
+With dkod's AST-level merging, almost nothing that feels like a dependency actually is one:
 
-```
-Wave 1 (parallel):
-  Unit: "Project scaffolding" — package.json, tsconfig, vite.config, main entry
-  Unit: "Design system" — colors, typography, component primitives, Tailwind config
-  Unit: "Database setup" — schema, migrations, connection, seed data
+| Situation | Why it is NOT a dependency |
+|---|---|
+| Two units edit the same file | dkod merges at the symbol level — different functions in the same file auto-merge |
+| Unit B imports a type that Unit A defines | Each generator inlines its own types. No waiting. |
+| Both units add to `package.json` | dkod merges JSON at the key level — additions from both units coexist |
+| Both units add routes to a router | dkod deduplicates and merges route registrations |
+| Unit B needs scaffolding that Unit A creates | Scaffolding runs in parallel. dkod merges the scaffolding output with feature code. |
+| Both units create test files for different modules | Completely independent — no conflict possible |
+| Unit B renders a component that Unit A creates | Unit B inlines a stub or its own version. The merge pass reconciles. |
+| Both units use the same utility library | Both import independently — no coordination needed |
 
-Wave 2 (parallel, after Wave 1):
-  Unit: "Auth API + Auth UI"
-  Unit: "Dashboard page + data fetching"
-  Unit: "Settings page + user preferences"
+**The only real constraint is symbol ownership.** No two units may create or modify the
+same function, component, or class. Everything else merges automatically.
 
-Wave 3 (parallel, after Wave 2):
-  Unit: "Integration tests"
-  Unit: "Error handling and loading states"
-  Unit: "Performance optimization"
-```
+### There Are No Dependencies
 
-**When to use:** Greenfield projects that need scaffolding before features.
+Every unit is independent. There are no dependency graphs. No wave assignments. No
+`depends_on` fields.
 
-## Dependency Analysis
-
-### What Creates a Dependency
-
-A unit depends on another when:
-- It imports a symbol that the other unit creates (e.g., importing a model from the schema unit)
-- It extends or implements a type from the other unit
-- It renders a component that the other unit creates
-- It reads data from a database table that the other unit defines
-- It calls an API endpoint that the other unit implements
-
-### What Does NOT Create a Dependency
-
-- Touching the same file (dkod handles this via AST merge)
-- Using the same utility library (both can import independently)
-- Adding to the same configuration file (e.g., both adding routes to a router — dkod deduplicates)
-- Creating parallel test files for different modules
-
-### Minimize Dependencies
-
-Every dependency serializes work. Strategies to reduce them:
-
-1. **Define interfaces early.** If Unit B needs a type from Unit A, can you put the interface
-   in a shared types file in a Wave 1 unit? Then both A and B can run in Wave 2.
-
-2. **Use dependency injection.** If Unit B needs Unit A's database connection, can Unit B
-   accept it as a parameter instead of importing it directly? Then both can be created in
-   parallel with a later integration unit.
-
-3. **Stub external dependencies.** If Unit B needs an API that Unit A builds, can Unit B use
-   mock data initially? Then a fix round can wire up the real connection.
-
-4. **Merge setup into fewer units.** If 5 units all depend on the same scaffolding, put all
-   scaffolding in one Wave 1 unit.
+If you catch yourself thinking "Unit B should run after Unit A" — stop. Inline what Unit B
+needs. Let dkod merge the results. The planner never sequences units; it dispatches them
+all at once and lets the merge engine handle the rest.
 
 ## Sizing Work Units
 


### PR DESCRIPTION
## Summary

- Remove the wave concept entirely from the harness. All work units now dispatch in a single blast — no waves, no `depends_on`, no dependency graphs, no parallelism scores
- dkod's AST-level merge handles file overlap, config merging, and import deduplication, so there is no reason to serialize generators
- Symbol ownership (`OWNS`) is the only structural constraint: no two units may create the same function/component/class
- Net -146 lines across 9 files — simpler model, more aggressive parallelism

### What changed

| File | Change |
|------|--------|
| `agents/planner.md` | Rewrote PRIME DIRECTIVE to "ALL UNITS DISPATCH SIMULTANEOUSLY". Killed dependency justification table, wave assignments, parallelism score. |
| `agents/orchestrator.md` | Replaced per-wave Build→Land loop with single-blast dispatch. Removed `waves`/`current_wave` state. Simplified all gates. |
| `skills/dkh/SKILL.md` | Rewrote flow diagram, gates, and work unit schema. Removed wave references. |
| `planning-guide.md` | Killed Pattern 2 (Layer-Based) and Pattern 4 (Setup + Feature Waves). Flipped "What Creates a Dependency" → "What is NOT a Dependency". |
| `dkod-patterns.md` | Killed Shared Types Pattern. Rewrote Greenfield Setup (scaffolding runs in parallel). Simplified landing pipeline. |
| `agents/evaluator.md` | Fixed incorrect claim that evaluators run simultaneously (they're sequential). |
| `agents/generator.md` | Removed "later wave" language. |
| `commands/plan.md` | Replaced wave breakdown with dispatch list. |
| `README.md` | Updated build step wording. |

## Test plan

- [ ] Run `/dkh` with a multi-unit project — verify all generators dispatch in one blast (no wave batching)
- [ ] Verify planner produces plans without `depends_on` or wave assignments
- [ ] Verify Gate 1 rejects plans with duplicate symbol ownership
- [ ] Verify no wave/dependency language appears in any agent prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)