### PR TITLE
Remove dangling pushed state variable from orchestrator

### DIFF
--- a/agents/orchestrator.md
+++ b/agents/orchestrator.md
@@ -218,7 +218,7 @@ Before proceeding, verify:
 If eval_reports is empty → **STOP. YOU SKIPPED PHASE 4. GO BACK.**
 
 Count results:
-- **All criteria PASS** → Set `pushed = true`, then `dk_push(mode: "pr")`. Include eval summary in PR description.
+- **All criteria PASS** → `dk_push(mode: "pr")`. Include eval summary in PR description.
   Done. Report the PR URL.
 
 - **Some FAIL, round < 3** → Execute the Round Transition
@@ -226,7 +226,7 @@ Count results:
   failed units. Each generator gets their evaluator's specific feedback.
   Then proceed through Phase 3 → Phase 4 → Phase 5.
 
-- **Round 3 exhausted** → Set `pushed = true`, then `dk_push(mode: "pr")` with issues documented. Report honestly.
+- **Round 3 exhausted** → `dk_push(mode: "pr")` with issues documented. Report honestly.
 
 **The PR description MUST include:**
 ```markdown


### PR DESCRIPTION
## Summary

- Removes two `Set pushed = true` references in Phase 5 (Ship or Fix) of `agents/orchestrator.md`
- The `pushed` variable was removed from the state block in PR #9 but these two references were missed
- Flagged by Greptile review as P1 outside-diff issue (reason PR #9 scored 4/5 instead of 5/5)

## Test plan

- [ ] Grep for `pushed` in orchestrator.md — zero results expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)