### PR TITLE
Add mandatory smoke test gate — app must start before eval or push

### DIFF
--- a/agents/orchestrator.md
+++ b/agents/orchestrator.md
@@ -200,6 +200,9 @@ failure, not an eval failure. DO NOT dispatch evaluators. Instead:
 - Treat ALL units as failed with feedback: "App crashes on startup: <error details>"
 - **Execute Round Transition** (see the "Round Transition" block below): increment `round`,
   wipe `changeset_ids`, `merged_commit`, `merge_failures`, `eval_reports`
+- **Check round cap**: if `round >= 3` after incrementing, do NOT re-dispatch.
+  Instead, `dk_push` with "app fails to start after 3 rounds" documented. This matches
+  the Phase 5 RETRY round-3 behavior.
 - Re-dispatch all generators with the crash error as feedback
 - After fix round, re-land, re-run smoke test
 

--- a/skills/dkh/SKILL.md
+++ b/skills/dkh/SKILL.md
@@ -207,7 +207,7 @@ USER PROMPT
    that Phase N-1's required output exists:
    - Phase 2 starts: "Do I have a plan with work units and criteria? YES → proceed"
    - Phase 3 starts: "Do I have changeset IDs from all dispatched generators? YES → proceed"
-   - Phase 4 starts: "Did at least one changeset merge? Do I have a commit hash? YES → proceed"
+   - Phase 4 starts: "Did the smoke test pass? Is the dev server running? YES → proceed"
    - Phase 5 starts: "Do I have eval reports for every unit? YES → proceed"
 
 5. **dk_verify is NOT evaluation.** `dk_verify` runs lint/type-check/test. It does NOT start


### PR DESCRIPTION
## Summary

The harness was creating PRs for apps that crash on first load. Root cause: eval gate only checked that eval reports exist, not that the app was actually tested. A "degraded eval report" escape hatch allowed bypassing live testing entirely.

### What this PR adds

**Smoke Test Gate** (between Phase 3 Land and Phase 4 Eval):
1. Start the dev server
2. Navigate to the app in the browser (chrome-devtools)
3. Take a screenshot — must show real content (not error overlay, not blank page, not crash)
4. Check console for fatal errors

- **Smoke test FAILS** → build failure, enter fix round with crash error as feedback. Do NOT dispatch evaluators.
- **Smoke test PASSES** → proceed to Phase 4 with server already running

### Other fixes
- Removed the "degraded eval report" escape hatch that allowed bypassing live testing
- Gate 4 now requires at least one screenshot in eval evidence
- Self-check before dk_push now has 4 items (smoke test, eval reports, screenshots, Phase 5)
- New gate enforcement rule #8: app must start and load before dk_push

## Test plan

- [ ] Verify smoke test section exists in orchestrator.md between Phase 3 and Phase 4
- [ ] Verify "degraded eval report" language is removed
- [ ] Verify Gate 4 requires screenshots
- [ ] Verify self-check has 4 items including smoke test
- [ ] Verify gate rule #8 exists in SKILL.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)