### PR TITLE
feat: add version to SKILL.md and auto-release on merge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,60 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Read version from SKILL.md frontmatter
+        id: version
+        run: |
+          VERSION=$(grep '^version:' skills/dkh/SKILL.md | head -1 | awk '{print $2}' | tr -d '[:space:]')
+          if [ -z "$VERSION" ]; then
+            echo "No version found in SKILL.md frontmatter"
+            exit 1
+          fi
+          echo "version=v${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Version: v${VERSION}"
+
+      - name: Check if tag exists
+        id: check
+        env:
+          TAG: ${{ steps.version.outputs.version }}
+        run: |
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Tag $TAG already exists, skipping release"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "Tag $TAG does not exist, creating release"
+          fi
+
+      - name: Generate release notes
+        if: steps.check.outputs.exists == 'false'
+        run: |
+          PREV_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          if [ -z "$PREV_TAG" ]; then
+            git log --oneline --no-merges | head -20 > /tmp/release-notes.txt
+          else
+            git log --oneline --no-merges "${PREV_TAG}..HEAD" > /tmp/release-notes.txt
+          fi
+
+      - name: Create release
+        if: steps.check.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.version.outputs.version }}
+        run: |
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --notes-file /tmp/release-notes.txt

--- a/skills/dkh/SKILL.md
+++ b/skills/dkh/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: dkh
+version: 0.1.0
 description: >
   Autonomous harness for building complete applications from a single prompt. Uses dkod for
   parallel agent execution with AST-level semantic merging. Orchestrates a Planner that decomposes


### PR DESCRIPTION
## Summary
- Adds `version: 0.1.0` to SKILL.md frontmatter — source of truth for the harness version
- Adds `.github/workflows/release.yml` that auto-creates a GitHub release on every merge to main when the version tag is new
- Release includes auto-generated commit notes

## How to release
1. Bump `version:` in `skills/dkh/SKILL.md` (e.g., `0.1.0` -> `0.1.1`)
2. Merge PR
3. Workflow creates GitHub release `v0.1.1` automatically

## Why
The harness shows "installed" with no version badge. With version in frontmatter + GitHub releases, the desktop app and skills CLI can display and track versions.