### PR TITLE
release: v0.1.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dkh",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Autonomous harness for parallel AI agent development. One prompt in, working tested app out. Powered by dkod's AST-level semantic merging and Anthropic's Planner-Generator-Evaluator architecture.",
   "author": {
     "name": "dkod",

--- a/skills/dkh/SKILL.md
+++ b/skills/dkh/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dkh
-version: 0.1.0
+version: 0.1.1
 description: >
   Autonomous harness for building complete applications from a single prompt. Uses dkod for
   parallel agent execution with AST-level semantic merging. Orchestrates a Planner that decomposes


### PR DESCRIPTION
## Release v0.1.1

Bumps version in SKILL.md frontmatter and plugin.json. On merge, the release workflow will create GitHub release v0.1.1.

### Changes since v0.1.0
- Review integration: dk_review in orchestrator, generator, evaluator
- Aggregation symbol enforcement in planner + Gate 1
- Per-changeset landing pipeline (verify → review → approve → merge)
- Version field in SKILL.md frontmatter
- Auto-release workflow