### PR TITLE
fix: auto-bump patch version and release on every merge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,50 +10,83 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    # Skip if this push was the auto-bump commit (prevents infinite loop)
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Read version from SKILL.md frontmatter
+      - name: Read current version and bump patch
         id: version
         run: |
-          VERSION=$(grep '^version:' skills/dkh/SKILL.md | head -1 | awk '{print $2}' | tr -d '[:space:]')
-          if [ -z "$VERSION" ]; then
+          CURRENT=$(grep '^version:' skills/dkh/SKILL.md | head -1 | awk '{print $2}' | tr -d '[:space:]')
+          if [ -z "$CURRENT" ]; then
             echo "No version found in SKILL.md frontmatter"
             exit 1
           fi
-          echo "version=v${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "Version: v${VERSION}"
+          echo "current=${CURRENT}" >> "$GITHUB_OUTPUT"
 
-      - name: Check if tag exists
-        id: check
+          # Bump patch: 0.1.2 -> 0.1.3
+          MAJOR=$(echo "$CURRENT" | cut -d. -f1)
+          MINOR=$(echo "$CURRENT" | cut -d. -f2)
+          PATCH=$(echo "$CURRENT" | cut -d. -f3)
+          NEW_PATCH=$((PATCH + 1))
+          NEW_VERSION="${MAJOR}.${MINOR}.${NEW_PATCH}"
+
+          echo "new=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tag=v${NEW_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Bumping: ${CURRENT} -> ${NEW_VERSION}"
+
+      - name: Update version in SKILL.md and plugin.json
         env:
-          TAG: ${{ steps.version.outputs.version }}
+          CURRENT: ${{ steps.version.outputs.current }}
+          NEW: ${{ steps.version.outputs.new }}
         run: |
-          if git rev-parse "$TAG" >/dev/null 2>&1; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-            echo "Tag $TAG already exists, skipping release"
-          else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-            echo "Tag $TAG does not exist, creating release"
+          sed -i "s/^version: ${CURRENT}/version: ${NEW}/" skills/dkh/SKILL.md
+          if [ -f .claude-plugin/plugin.json ]; then
+            sed -i "s/\"version\": \"${CURRENT}\"/\"version\": \"${NEW}\"/" .claude-plugin/plugin.json
           fi
 
+          # Verify the bump worked
+          VERIFY=$(grep '^version:' skills/dkh/SKILL.md | head -1 | awk '{print $2}' | tr -d '[:space:]')
+          if [ "$VERIFY" != "$NEW" ]; then
+            echo "ERROR: Version bump failed. Expected ${NEW}, got ${VERIFY}"
+            exit 1
+          fi
+          echo "Version bumped to ${NEW}"
+
+      - name: Commit version bump
+        env:
+          NEW: ${{ steps.version.outputs.new }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add skills/dkh/SKILL.md .claude-plugin/plugin.json
+          git commit -m "release: v${NEW} [skip ci]"
+          git push
+
       - name: Generate release notes
-        if: steps.check.outputs.exists == 'false'
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
         run: |
           PREV_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
           if [ -z "$PREV_TAG" ]; then
             git log --oneline --no-merges | head -20 > /tmp/release-notes.txt
           else
-            git log --oneline --no-merges "${PREV_TAG}..HEAD" > /tmp/release-notes.txt
+            # Exclude the auto-bump commit from notes
+            git log --oneline --no-merges "${PREV_TAG}..HEAD" | grep -v "\[skip ci\]" > /tmp/release-notes.txt
+          fi
+          # If empty (only skip-ci commits), add a placeholder
+          if [ ! -s /tmp/release-notes.txt ]; then
+            echo "Patch release" > /tmp/release-notes.txt
           fi
 
       - name: Create release
-        if: steps.check.outputs.exists == 'false'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ steps.version.outputs.version }}
+          TAG: ${{ steps.version.outputs.tag }}
         run: |
           gh release create "$TAG" \
             --title "$TAG" \


### PR DESCRIPTION
## Summary
Changes the release workflow from manual version bumps to auto-increment.

### Before
- Merge PR → workflow checks if tag exists → skips if no version bump
- Had to manually bump version in SKILL.md to trigger a release

### After  
- Merge PR → workflow bumps patch version → commits with [skip ci] → creates release
- Every merge produces a release automatically
- No infinite loop: the auto-commit has [skip ci] in the message, workflow checks `if: "!contains(github.event.head_commit.message, '[skip ci]')"`

### Flow
```
PR merged → 0.1.2 read → bumped to 0.1.3 → commit [skip ci] → tag v0.1.3 → release created
Next PR merged → 0.1.3 read → bumped to 0.1.4 → commit [skip ci] → ...
```