### PR TITLE
chore: trigger auto-release workflow

### DIFF
--- a/skills/dkh/SKILL.md
+++ b/skills/dkh/SKILL.md
@@ -443,3 +443,4 @@ The Planner produces work units in this structure (embedded in the plan artifact
 - `references/planning-guide.md` — deep guide for symbol-level decomposition
 - `references/evaluation-guide.md` — skeptical evaluation techniques and chrome-devtools patterns
 - `references/dkod-patterns.md` — dkod session lifecycle and merge patterns
+


### PR DESCRIPTION
Triggers the release workflow to verify auto-bump works. Previous PR had skip-ci in its commit message which prevented the workflow from running on merge.