### PR TITLE
Add Gate 1 self-check to planner agent

### DIFF
--- a/agents/planner.md
+++ b/agents/planner.md
@@ -351,6 +351,23 @@ All units dispatch simultaneously: [Unit 1, Unit 2, Unit 3, Unit 4, Unit 5, Unit
 ...
 ```
 
+## Pre-Output Self-Check (Gate 1)
+
+Before finalizing your plan, verify ALL of these. The orchestrator will reject your plan
+if any check fails — save a round trip by catching it yourself:
+
+- [ ] Specification includes stack, features, and data model
+- [ ] Every work unit has `OWNS (exclusive)` with specific symbol names
+- [ ] No two units own the same symbol (check for duplicates across all OWNS lists)
+- [ ] Aggregation symbols table exists — entry points (App, router, main, index) each
+  have exactly one owner
+- [ ] Every work unit has 5+ testable acceptance criteria
+- [ ] Overall acceptance criteria exist (app starts, no console errors, responsive, etc.)
+- [ ] **For UI projects**: Design Direction section exists with specific tone (not "modern
+  and clean"), hex color values, and named font choices (not Arial/Inter/Roboto)
+
+If any check fails, fix the plan before outputting it.
+
 ## Rules
 
 1. **All units dispatch simultaneously. There are no waves, no dependencies.** Every unit


### PR DESCRIPTION
## Summary

The four agent files (`agents/planner.md`, `agents/generator.md`, `agents/evaluator.md`, `agents/orchestrator.md`) are already comprehensive and self-contained — each is a complete prompt that a subagent can execute without reading SKILL.md.

After auditing all four files against every SKILL.md requirement, only one gap was found:

- **Planner was missing an explicit Gate 1 self-check** before outputting the plan. It understood the constraints implicitly (symbol ownership, aggregation symbols, design direction, etc.) but didn't run a verification pass before finalizing. The orchestrator would catch failures, but that wastes a round trip.

This PR adds a 7-point "Pre-Output Self-Check (Gate 1)" section to `agents/planner.md` that mirrors the orchestrator's Gate 1 checks.

## Audit results (no changes needed)

| Agent | Lines | Status |
|-------|-------|--------|
| planner.md | 386 | Fixed (added self-check) |
| generator.md | 210 | Complete — all 6 SKILL.md specs present |
| evaluator.md | 537 | Complete — all 7 SKILL.md specs present |
| orchestrator.md | 511 | Complete — all 8 SKILL.md specs present |

## Test plan

- [ ] Verify self-check section exists in planner.md before Rules section
- [ ] Verify 7 checklist items match orchestrator Gate 1 checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)