### PR TITLE
fix: make conflict_warnings a hard gate — NEVER submit with unresolved conflicts

### DIFF
--- a/skills/dkh/agents/generator.md
+++ b/skills/dkh/agents/generator.md
@@ -287,6 +287,9 @@ session_id and changeset_id back to the orchestrator and **exit immediately**. D
 `dk_merge`, `dk_approve`, `dk_push`, or `dk_verify` — the orchestrator lands all changesets
 in the correct dependency order during Phase 3.
 
+**Use the appropriate report template based on your exit condition:**
+
+**Template A — Successful submit:**
 ```
 ## Generator Report: <unit title>
 
@@ -301,7 +304,24 @@ in the correct dependency order during Phase 3.
 **Notes:** <any implementation decisions, assumptions, or concerns>
 ```
 
-**After outputting this report, you are DONE. Return control to the orchestrator.**
+**Template B — Blocked by unresolved conflict (could not submit):**
+```
+## Generator Report: <unit title>
+
+**Status:** conflict_blocked
+**Session ID:** <from dk_connect response>
+**Changeset ID:** NONE — dk_submit was NOT called (conflict gate blocked it)
+**Conflicting file:** <path of the file with unresolved conflict_warnings>
+**Conflicting agent:** <agent name from the conflict_warning>
+**Attempts to resolve:** <number of dk_file_write retries attempted>
+**Notes:** <what was tried, why resolution failed>
+```
+
+**CRITICAL: Template B MUST include the Session ID.** The orchestrator needs it to call
+`dk_close` on your orphaned session and release symbol claims. Without it, re-dispatched
+generators will self-conflict on the same symbols.
+
+**After outputting either report, you are DONE. Return control to the orchestrator.**
 
 ## When You're Re-Dispatched (Fix Round)
 

--- a/skills/dkh/agents/generator.md
+++ b/skills/dkh/agents/generator.md
@@ -106,22 +106,28 @@ for each file in your work unit:
   # 4. ═══ HARD GATE: CHECK conflict_warnings ═══
   if response contains conflict_warnings:
     has_unresolved_conflicts = true
+    attempts = 0
+    MAX_ATTEMPTS = 3
 
     # STOP writing new files. Resolve this conflict FIRST:
-    # a) The warning tells you WHO is modifying the same symbols
-    # b) Call dk_watch() to see their submitted changes
-    # c) Call dk_file_read(path) to get the current merged version
-    # d) Rewrite YOUR file to work alongside THEIR changes
-    #    - Keep their exports/symbols intact
-    #    - Adjust your code to complement, not overwrite
-    #    - Use their import paths and export names
-    # e) Call dk_file_write(path, adapted_content)
-    # f) If the new response has NO conflict_warnings → resolved
-    #    has_unresolved_conflicts = false
-    #    Continue with remaining files
-    # g) If conflict_warnings PERSIST after 3 attempts → STOP.
-    #    Report to orchestrator: "Unresolvable conflict on <path> with <agent>"
-    #    Do NOT proceed to dk_submit.
+    while response contains conflict_warnings AND attempts < MAX_ATTEMPTS:
+      attempts += 1
+      # a) The warning tells you WHO is modifying the same symbols
+      # b) Call dk_watch() to see their submitted changes
+      # c) Call dk_file_read(path) to get the current merged version
+      # d) Rewrite YOUR file to work alongside THEIR changes
+      #    - Keep their exports/symbols intact
+      #    - Adjust your code to complement, not overwrite
+      #    - Use their import paths and export names
+      # e) response = dk_file_write(path, adapted_content)
+
+    if response contains no conflict_warnings:
+      has_unresolved_conflicts = false   # resolved — continue with remaining files
+    else:
+      # All 3 attempts exhausted — conflict is unresolvable
+      # STOP. Report to orchestrator using Template B (or Template C if
+      # a dk_submit already succeeded in an earlier round).
+      # Do NOT proceed to dk_submit.
 ```
 
 **═══ SUBMIT GATE ═══**
@@ -199,7 +205,11 @@ CHECK 2: dk_watch() — adapt to other generators' changes
   - Call dk_watch() one final time
   - If events show other generators submitted changes to files/symbols
     your code imports from → verify your imports still match
-  - If mismatched → fix with dk_file_write NOW (and check for conflict_warnings!)
+  - If mismatched → fix with dk_file_write NOW
+  - If that dk_file_write returns conflict_warnings → treat as a new Step 3
+    conflict: set has_unresolved_conflicts = true and resolve using the
+    Step 3 resolution loop (dk_watch → dk_file_read → adapt → dk_file_write,
+    max 3 attempts) before proceeding
 
 CHECK 3: Self-review
   - Re-read each file you wrote with dk_file_read

--- a/skills/dkh/agents/generator.md
+++ b/skills/dkh/agents/generator.md
@@ -72,87 +72,90 @@ Call `dk_context` with queries relevant to your work unit:
 
 Call `dk_file_read` for any files you need to understand before modifying them.
 
-### Step 3: Implement — with Real-Time Cross-Agent Awareness
+### Step 3: Implement — CONFLICT_WARNINGS ARE HARD GATES
 
-**CRITICAL: You are NOT blind to other generators.** dkod provides real-time events from
-all parallel agents via `dk_watch`. You MUST use this to coordinate imports and exports
-with other generators. Ignoring `dk_watch` during implementation causes import mismatches
-that break the build after merge.
+**CRITICAL: Every `dk_file_write` response MUST be checked for `conflict_warnings`.
+If conflict_warnings are present, you MUST resolve them BEFORE writing any more files
+and BEFORE calling dk_submit. Submitting with unresolved conflict_warnings is a
+HARNESS VIOLATION — your changeset WILL be rejected at merge and the entire build fails.**
+
+This is the core coordination mechanism of dkod. Multiple generators write to the same
+codebase simultaneously. `dk_file_write` tells you IN REAL TIME if another generator is
+modifying the same symbols. You MUST respond to these warnings — they are not informational,
+they are hard gates.
 
 **The implementation loop:**
 
 ```
+has_unresolved_conflicts = false
+
 for each file in your work unit:
 
-  # 1. CHECK WHAT OTHER GENERATORS HAVE DONE
-  dk_watch()  — returns all events since last call (file writes, submits, etc.)
-  
-  # Look at file_write events from other generators:
-  # - What files did they create? What paths?
-  # - What symbols did they export? What names?
-  # - Do any of YOUR imports depend on THEIR files?
-  #
-  # If you see that another generator created a file you need to import from,
-  # use THEIR actual path and export names — not what you assumed.
+  # 1. Call dk_watch() to check for events from other generators
+  #    (submitted changesets, review completions, etc.)
+  dk_watch()
 
   # 2. READ the file (if it exists)
   dk_file_read(path)
 
-  # 3. WRITE the file — using real import paths from dk_watch events
-  dk_file_write(path, content)
+  # 3. WRITE the file
+  response = dk_file_write(path, content)
 
-  # 4. CHECK for conflict_warnings in the response
-  if conflict_warnings:
-    # Another generator merged changes to the same symbols.
-    # Read their version from the warning, rewrite to incorporate both, re-write.
-    # Do NOT call dk_connect. Retry dk_file_write with combined content.
+  # 4. ═══ HARD GATE: CHECK conflict_warnings ═══
+  if response contains conflict_warnings:
+    has_unresolved_conflicts = true
+
+    # STOP writing new files. Resolve this conflict FIRST:
+    # a) The warning tells you WHO is modifying the same symbols
+    # b) Call dk_watch() to see their submitted changes
+    # c) Call dk_file_read(path) to get the current merged version
+    # d) Rewrite YOUR file to work alongside THEIR changes
+    #    - Keep their exports/symbols intact
+    #    - Adjust your code to complement, not overwrite
+    #    - Use their import paths and export names
+    # e) Call dk_file_write(path, adapted_content)
+    # f) If the new response has NO conflict_warnings → resolved
+    #    has_unresolved_conflicts = false
+    #    Continue with remaining files
+    # g) If conflict_warnings PERSIST after 3 attempts → STOP.
+    #    Report to orchestrator: "Unresolvable conflict on <path> with <agent>"
+    #    Do NOT proceed to dk_submit.
 ```
 
-**Why dk_watch matters:** Other generators are writing files RIGHT NOW. If Generator B
-creates `src/state/appReducer.ts` exporting `{ AppState, AppAction }`, and your unit needs
-those types, you MUST import from `src/state/appReducer.ts` using those exact names — not
-guess a path like `src/types/index.ts` or a name like `{ State }`. `dk_watch` tells you
-what actually exists.
+**═══ SUBMIT GATE ═══**
+**You CANNOT call dk_submit if `has_unresolved_conflicts` is true.**
+Submitting with unresolved conflict_warnings guarantees a merge failure in Phase 3.
+Resolve ALL conflict_warnings first, or report the unresolvable conflict to the orchestrator.
 
-**When to call dk_watch:**
-- **Before writing any file that imports from another unit's symbols** — check what they
-  actually created
-- **After writing a batch of files** — check if events arrived that affect remaining files
-- **Before submitting** — final check that your imports match reality
+**Why this matters:** When you call `dk_file_write` and get a conflict_warning like:
+```
+CONFLICT WARNING:
+  generator-unit-3 is also modifying BoardPage in this file
+  Your changes may be rejected at SUBMIT time.
+```
+This means another generator has already claimed or written to the same symbol. If you
+submit without resolving, Phase 3 merge WILL fail, wasting the entire build cycle.
 
-**What to look for in dk_watch events:**
-- `file_write` events from other generators → actual file paths and symbol names
-- `changeset.submitted` events → that generator is done, their files are final
-- `conflict_warnings` on any symbol you also touch
+**What to do when you see conflict_warnings:**
 
-**If dk_watch shows no events yet** (you're faster than other generators), write your files
-using the paths from the plan spec. Other generators will see YOUR file_write events via
-their dk_watch and adapt to YOUR paths. The first generator to write a shared interface
-sets the convention — others follow.
-
-**Handling conflict_warnings from dk_file_write:**
-If the dk_file_write response contains `conflict_warnings`:
-1. **Stop** — do not write more files
-2. **Read the merged version** from the warning (it includes their code)
-3. **Rewrite your file** to incorporate both changes
-4. **Re-call `dk_file_write`** — do NOT call dk_connect
-5. If warnings persist after 3 rewrites, proceed — the merge handler catches the rest
+1. **Call `dk_watch()`** — check what the other generator submitted
+2. **Call `dk_file_read(path)`** — get the current state including their changes
+3. **Adapt your code:**
+   - If they wrote a page component and you also need that page → DON'T overwrite.
+     Import and extend their version, or add your functionality to their component.
+   - If they exported symbols you need → use their exact names and paths
+   - If your symbols overlap → rename yours or merge the implementations
+4. **Call `dk_file_write` with the adapted content**
+5. **Verify no conflict_warnings remain** before continuing
 
 **Implementation principles:**
 
-- **Write complete files.** dk_file_write takes full file content, not patches. Read the
-  existing file, make your changes, write the whole thing back.
-- **Follow existing patterns.** If the codebase uses semicolons, use semicolons. If it uses
-  tabs, use tabs. Match the style.
-- **Import from reality, not assumptions.** Use `dk_watch` to see what other generators
-  actually created. Use THEIR paths and export names in your imports. Never guess.
-- **Export what the plan specifies.** If other units depend on your symbols, export them
-  with the exact names from the work unit spec. Other generators will see your file_write
-  events and use your actual paths.
-- **Write tests if specified.** If your work unit includes test criteria, write the test files
-  too.
-- **Don't half-finish.** Every acceptance criterion for your unit must be addressed in your
-  implementation. Don't leave TODOs.
+- **Write complete files.** dk_file_write takes full file content, not patches.
+- **Follow existing patterns.** Match the codebase style.
+- **NEVER ignore conflict_warnings.** They are hard gates, not suggestions.
+- **Export what the plan specifies.** Use exact names from the work unit spec.
+- **Write tests if specified.**
+- **Don't half-finish.** Every acceptance criterion must be addressed.
 
 ### Frontend Design — MANDATORY for UI work units
 
@@ -177,23 +180,38 @@ After invoking the skill, follow its guidelines when implementing your unit:
 on white, cookie-cutter cards, Inter font, no personality) will FAIL evaluation. The
 `frontend-design` skill exists to prevent this — use it.
 
-### Step 4: Self-Check — Verify Imports Against Reality
+### Step 4: Pre-Submit Gate — MANDATORY
 
-**Before submitting, you MUST verify your imports match what other generators actually created.**
+**You MUST pass ALL checks before calling dk_submit. Skipping any check is a harness violation.**
 
-1. **Call `dk_watch()`** — get all remaining events from other generators
-2. **For every import in your files that references another unit's symbols:**
-   - Check dk_watch events: did that generator create the file at the path you're importing?
-   - Do the export names match what you're importing?
-   - If there's a mismatch → fix your import path/names with `dk_file_write` NOW
-3. **Re-read each file you wrote** with `dk_file_read`
-4. Check that all acceptance criteria for your unit are addressed
-5. Verify exported symbols match what other units expect (from the plan spec)
-6. Check for obvious bugs: typos, wrong variable names, missing error handling
+```
+═══ PRE-SUBMIT GATE ═══
 
-**This step prevents the #1 cause of build failures after merge: import mismatches between
-generators.** Skipping this step means the smoke test will fail and you'll waste an entire
-fix round.
+CHECK 1: No unresolved conflict_warnings
+  - If ANY dk_file_write returned conflict_warnings that you did not resolve
+    → STOP. Go back to Step 3 and resolve them.
+  - You can verify by re-reading your files with dk_file_read — if the content
+    matches what you wrote and no warnings fired, you're clean.
+
+CHECK 2: dk_watch() — adapt to other generators' changes
+  - Call dk_watch() one final time
+  - If events show other generators submitted changes to files/symbols
+    your code imports from → verify your imports still match
+  - If mismatched → fix with dk_file_write NOW (and check for conflict_warnings!)
+
+CHECK 3: Self-review
+  - Re-read each file you wrote with dk_file_read
+  - All acceptance criteria addressed
+  - Exported symbols match what other units expect (from plan spec)
+  - No obvious bugs: typos, wrong variable names, missing error handling
+
+ALL THREE CHECKS MUST PASS. Only then proceed to dk_submit.
+```
+
+**This gate exists because:**
+- Unresolved conflict_warnings → merge failure in Phase 3 (100% guaranteed)
+- Stale imports → smoke test failure after merge
+- Missing criteria → eval failure in Phase 4
 
 ### Step 5: Submit and Review-Fix Loop
 
@@ -300,11 +318,15 @@ orchestrator. You call `dk_connect` once (your one allowed call for this executi
 
 ## Rules
 
-1. **Be fast.** The build waits for the slowest generator. Parallelize file reads. Don't over-engineer.
-2. **Stay in your lane.** Only modify symbols assigned to your unit.
-3. **Don't merge.** Only submit. The orchestrator handles landing (Phase 3).
-4. **Coordinate via dk_watch, not direct communication.** Call `dk_watch()` to see what other generators created — use their actual paths and export names in your imports (see Step 3).
-5. **Be thorough.** Implement all criteria. Handle edge cases (error/empty/loading states).
-6. **Batch reads, check writes.** Read upfront. Call `dk_watch()` + check `conflict_warnings` before each write.
-7. **No package installs.** Never run npm/bun/pip install or npx/bunx. Orchestrator handles deps.
-8. **Bash timeout.** If you must run Bash, always prefix with `timeout 30`.
+1. **NEVER submit with unresolved conflict_warnings.** This is the #1 rule. Every
+   `dk_file_write` response MUST be checked. If conflict_warnings exist, resolve them
+   BEFORE dk_submit. Submitting with conflicts breaks the entire build. See Step 3.
+2. **NEVER call dk_connect more than once.** See the dk_connect guard above.
+3. **Call dk_watch() before dk_submit.** Check for other generators' changes. Adapt imports
+   and shared symbols. Pass the Pre-Submit Gate (Step 4) before submitting.
+4. **Stay in your lane.** Only modify symbols assigned to your unit.
+5. **Don't merge.** Only submit. The orchestrator handles landing (Phase 3).
+6. **Be fast.** The build waits for the slowest generator. Parallelize file reads.
+7. **Be thorough.** Implement all criteria. Handle edge cases (error/empty/loading states).
+8. **No package installs.** Never run npm/bun/pip install or npx/bunx. Orchestrator handles deps.
+9. **Bash timeout.** If you must run Bash, always prefix with `timeout 30`.

--- a/skills/dkh/agents/generator.md
+++ b/skills/dkh/agents/generator.md
@@ -26,7 +26,9 @@ writes, no changeset is created, and the build breaks. If `dk_connect` fails, ST
 **Time budget:** The orchestrator has allocated you a time budget (typically 45 minutes).
 If running low on time, submit what you have via `dk_submit` — a partial changeset is
 better than no changeset (timeout = crash). Prioritize: get the core functionality working
-first, then handle edge cases if time permits.
+first, then handle edge cases if time permits. **Exception: if `has_unresolved_conflicts`
+is true, you MUST NOT submit even under time pressure. Report the unresolved conflict to
+the orchestrator instead — a conflicting changeset is worse than no changeset.**
 
 ## THE PRIME DIRECTIVE: MAXIMIZE PARALLELISM
 

--- a/skills/dkh/agents/generator.md
+++ b/skills/dkh/agents/generator.md
@@ -311,7 +311,7 @@ in the correct dependency order during Phase 3.
 **Notes:** <any implementation decisions, assumptions, or concerns>
 ```
 
-**Template B — Blocked by unresolved conflict (could not submit):**
+**Template B — Blocked by unresolved conflict BEFORE first submit (no changeset_id):**
 ```
 ## Generator Report: <unit title>
 
@@ -324,9 +324,28 @@ in the correct dependency order during Phase 3.
 **Notes:** <what was tried, why resolution failed>
 ```
 
-**CRITICAL: Template B MUST include the Session ID.** The orchestrator needs it to call
-`dk_close` on your orphaned session and release symbol claims. Without it, re-dispatched
-generators will self-conflict on the same symbols.
+**Template C — Conflict during review-fix loop AFTER a successful submit:**
+```
+## Generator Report: <unit title>
+
+**Status:** conflict_blocked_after_submit
+**Session ID:** <from dk_connect response>
+**Changeset ID:** <from the EARLIER successful dk_submit — this is valid, do NOT omit it>
+**Last successful review score:** <score from the round that succeeded>
+**Rounds completed before conflict:** <round number>
+**Conflicting file:** <path of the file with unresolved conflict_warnings>
+**Conflicting agent:** <agent name from the conflict_warning>
+**Notes:** <what was tried, why resolution failed during review-fix>
+```
+
+**CRITICAL: Choose the right template.**
+- Template B: conflict blocked you BEFORE your first dk_submit → no changeset_id exists.
+- Template C: you submitted successfully, then hit a conflict during review-fix → your
+  changeset_id from the earlier submit IS VALID and MUST be reported. The orchestrator
+  will use it in Phase 3 (the earlier submitted version may still be mergeable).
+
+**Both templates MUST include the Session ID.** The orchestrator needs it to call
+`dk_close` on your session and release symbol claims.
 
 **After outputting either report, you are DONE. Return control to the orchestrator.**
 

--- a/skills/dkh/agents/generator.md
+++ b/skills/dkh/agents/generator.md
@@ -237,7 +237,12 @@ LOOP while round ≤ 3:
   # Check LOCAL review (inline with dk_submit response)
   if local review has severity:"error" findings:
     OUTPUT: "Review-fix round {round}/3: fixing {N} findings (score: {score}/5)"
-    fix the files
+    fix the files via dk_file_write
+    # ═══ CONFLICT CHECK — same rule as Step 3 ═══
+    # Every dk_file_write in the review-fix loop MUST be checked for
+    # conflict_warnings. If present, resolve BEFORE re-submitting.
+    # The hard gate applies here too — no exceptions for review fixes.
+    if any dk_file_write returned conflict_warnings → resolve (see Step 3)
     round += 1
     if round > 3 → break
     dk_submit again
@@ -253,7 +258,9 @@ LOOP while round ≤ 3:
 
   # Deep found issues — fix and re-submit
   OUTPUT: "Review-fix round {round}/3: fixing {N} deep findings (score: {score}/5)"
-  fix files based on deep findings
+  fix files based on deep findings via dk_file_write
+  # ═══ CONFLICT CHECK — same rule as Step 3 ═══
+  if any dk_file_write returned conflict_warnings → resolve (see Step 3)
   round += 1
   if round > 3:
     OUTPUT: "Max review rounds reached — final score: {score}/5"

--- a/skills/dkh/agents/orchestrator.md
+++ b/skills/dkh/agents/orchestrator.md
@@ -219,10 +219,12 @@ Wait for all generators to complete.
 
 - **Status: conflict_blocked_after_submit** → the generator submitted successfully but
   hit an unresolvable conflict during the review-fix loop. It HAS a valid changeset_id
-  from the earlier submit. Record BOTH session_id and changeset_id in `session_map`.
+  from the earlier submit. Record the changeset_id in `changeset_ids`.
+  **Call `dk_close(session_id)`** to release symbol claims from the abandoned review-fix
+  writes — without this, fix-round generators will hit spurious conflicts.
   **Treat this as a successful submit for Phase 3** — the earlier changeset is valid
   and may merge cleanly (the conflict was on the review-fix rewrite, not the original).
-  Output: `Generator **[unit-name]** conflict during review-fix — using earlier changeset [id], score [X/5]. Progress: N/M done.`
+  Output: `Generator **[unit-name]** conflict during review-fix — closing session [sid], using earlier changeset [id], score [X/5]. Progress: N/M done.`
 
 - **No report / crashed** → record whatever session_id is available from the dispatch.
 

--- a/skills/dkh/agents/orchestrator.md
+++ b/skills/dkh/agents/orchestrator.md
@@ -238,7 +238,7 @@ Before proceeding, verify:
 1. Call `dk_close(session_id)` for each conflict_blocked generator (if not already closed above)
 2. For each conflict_blocked generator:
    - Increment `unit_attempts[unit_id]`
-   - If `unit_attempts[unit_id] >= 3` → move to `blocked_units`, skip re-dispatch
+   - If `unit_attempts[unit_id] >= 3` → move to `blocked_units`, **remove from `active_units`**, skip re-dispatch
    - Otherwise → re-dispatch with feedback:
      "Your previous attempt was blocked by a conflict on <file> with <agent>.
      That agent's changeset is now submitted. Call dk_watch() first, adapt to their

--- a/skills/dkh/agents/orchestrator.md
+++ b/skills/dkh/agents/orchestrator.md
@@ -228,12 +228,16 @@ Before proceeding, verify:
 
 **If any generators are conflict_blocked:**
 1. Call `dk_close(session_id)` for each conflict_blocked generator (if not already closed above)
-2. Re-dispatch ONLY the conflict_blocked generators with feedback:
-   "Your previous attempt was blocked by a conflict on <file> with <agent>.
-   That agent's changeset is now submitted. Call dk_watch() first, adapt to their
-   changes, then implement your unit."
-3. Wait for re-dispatched generators to complete
-4. Re-check Gate 2
+2. For each conflict_blocked generator:
+   - Increment `unit_attempts[unit_id]`
+   - If `unit_attempts[unit_id] >= 3` → move to `blocked_units`, skip re-dispatch
+   - Otherwise → re-dispatch with feedback:
+     "Your previous attempt was blocked by a conflict on <file> with <agent>.
+     That agent's changeset is now submitted. Call dk_watch() first, adapt to their
+     changes, then implement your unit."
+3. If all conflict_blocked generators are now in `blocked_units` → fall through to
+   gate pass with whatever submitted changesets exist (forced-ship with documented gaps)
+4. Otherwise → wait for re-dispatched generators to complete, re-check Gate 2
 
 **If any generators crashed** (no report at all):
 - If they have a recorded session_id → call `dk_close(session_id)` to release claims

--- a/skills/dkh/agents/orchestrator.md
+++ b/skills/dkh/agents/orchestrator.md
@@ -252,7 +252,9 @@ Before proceeding, verify:
 - Re-dispatch. Do NOT proceed until all have submitted.
 
 **If gate passes** (all generators have status: submitted or conflict_blocked_after_submit, all have changeset_ids):
-→ set `changeset_ids = [...]` and verify `session_map` has an entry for each changeset_id.
+→ set `changeset_ids = [...]` and verify `session_map` has an entry for each changeset_id
+  **whose generator reported `submitted`** (conflict_blocked_after_submit sessions are
+  already closed and do not need a session_map entry).
 > **Gate 2 PASSED** — `changeset_ids: [id1, id2, ...]`, `active_units: [N units]`. Proceeding to Phase 3 (Land).
 
 ---

--- a/skills/dkh/agents/orchestrator.md
+++ b/skills/dkh/agents/orchestrator.md
@@ -207,19 +207,40 @@ Other units' acceptance criteria are noise that wastes context tokens.
 
 Wait for all generators to complete.
 
-**As each generator completes**, record its session_id and changeset_id in `session_map`, then output a progress line:
-> Generator **[unit-name]** complete — session `[sid]`, changeset `[id]`, self-score [X/5]. Progress: **N/M generators done.**
+**As each generator completes**, check its report status:
 
-This keeps the user informed as changesets arrive instead of showing a stale empty state for the entire build phase.
+- **Status: submitted** → record session_id and changeset_id in `session_map`.
+  Output: `Generator **[unit-name]** complete — session [sid], changeset [id], score [X/5]. Progress: N/M done.`
+
+- **Status: conflict_blocked** → the generator could NOT submit due to unresolved
+  conflict_warnings. Record its session_id (from the report) but NO changeset_id.
+  **Immediately call `dk_close(session_id)`** to release its symbol claims — without
+  this, the re-dispatched generator will self-conflict on the same file.
+  Output: `Generator **[unit-name]** CONFLICT_BLOCKED — closing session [sid], will re-dispatch. Progress: N/M done.`
+
+- **No report / crashed** → record whatever session_id is available from the dispatch.
 
 **═══ GATE 2 CHECK ═══**
 Before proceeding, verify:
 - [ ] Every generator has reported back
-- [ ] Every report includes a changeset_id
-- [ ] `changeset_ids` has one entry per unit in `active_units`
+- [ ] Count generators with `status: submitted` and a changeset_id
+- [ ] Count generators with `status: conflict_blocked` (no changeset_id)
 
-**If gate fails** → for each crashed generator that has a recorded changeset_id, call `dk_close(session_map[changeset_id])` to release its claims. Then re-dispatch. Do NOT proceed until all have submitted.
-**If gate passes** → set `changeset_ids = [...]` and verify `session_map` has an entry for each changeset_id. Output the updated state block:
+**If any generators are conflict_blocked:**
+1. Call `dk_close(session_id)` for each conflict_blocked generator (if not already closed above)
+2. Re-dispatch ONLY the conflict_blocked generators with feedback:
+   "Your previous attempt was blocked by a conflict on <file> with <agent>.
+   That agent's changeset is now submitted. Call dk_watch() first, adapt to their
+   changes, then implement your unit."
+3. Wait for re-dispatched generators to complete
+4. Re-check Gate 2
+
+**If any generators crashed** (no report at all):
+- If they have a recorded session_id → call `dk_close(session_id)` to release claims
+- Re-dispatch. Do NOT proceed until all have submitted.
+
+**If gate passes** (all generators have status: submitted with changeset_ids):
+→ set `changeset_ids = [...]` and verify `session_map` has an entry for each changeset_id.
 > **Gate 2 PASSED** — `changeset_ids: [id1, id2, ...]`, `active_units: [N units]`. Proceeding to Phase 3 (Land).
 
 ---

--- a/skills/dkh/agents/orchestrator.md
+++ b/skills/dkh/agents/orchestrator.md
@@ -213,17 +213,23 @@ Wait for all generators to complete.
   Output: `Generator **[unit-name]** complete — session [sid], changeset [id], score [X/5]. Progress: N/M done.`
 
 - **Status: conflict_blocked** → the generator could NOT submit due to unresolved
-  conflict_warnings. Record its session_id (from the report) but NO changeset_id.
-  **Immediately call `dk_close(session_id)`** to release its symbol claims — without
-  this, the re-dispatched generator will self-conflict on the same file.
+  conflict_warnings BEFORE its first dk_submit. No changeset_id exists.
+  Record its session_id. **Immediately call `dk_close(session_id)`** to release claims.
   Output: `Generator **[unit-name]** CONFLICT_BLOCKED — closing session [sid], will re-dispatch. Progress: N/M done.`
+
+- **Status: conflict_blocked_after_submit** → the generator submitted successfully but
+  hit an unresolvable conflict during the review-fix loop. It HAS a valid changeset_id
+  from the earlier submit. Record BOTH session_id and changeset_id in `session_map`.
+  **Treat this as a successful submit for Phase 3** — the earlier changeset is valid
+  and may merge cleanly (the conflict was on the review-fix rewrite, not the original).
+  Output: `Generator **[unit-name]** conflict during review-fix — using earlier changeset [id], score [X/5]. Progress: N/M done.`
 
 - **No report / crashed** → record whatever session_id is available from the dispatch.
 
 **═══ GATE 2 CHECK ═══**
 Before proceeding, verify:
 - [ ] Every generator has reported back
-- [ ] Count generators with `status: submitted` and a changeset_id
+- [ ] Count generators with `status: submitted` or `status: conflict_blocked_after_submit` (have changeset_id)
 - [ ] Count generators with `status: conflict_blocked` (no changeset_id)
 
 **If any generators are conflict_blocked:**
@@ -243,7 +249,7 @@ Before proceeding, verify:
 - If they have a recorded session_id → call `dk_close(session_id)` to release claims
 - Re-dispatch. Do NOT proceed until all have submitted.
 
-**If gate passes** (all generators have status: submitted with changeset_ids):
+**If gate passes** (all generators have status: submitted or conflict_blocked_after_submit, all have changeset_ids):
 → set `changeset_ids = [...]` and verify `session_map` has an entry for each changeset_id.
 > **Gate 2 PASSED** — `changeset_ids: [id1, id2, ...]`, `active_units: [N units]`. Proceeding to Phase 3 (Land).
 

--- a/skills/dkh/agents/orchestrator.md
+++ b/skills/dkh/agents/orchestrator.md
@@ -89,13 +89,23 @@ session_map: {}             # { changeset_id: session_id } — populated from ea
 
 ---
 
-### PRE-FLIGHT — VERIFY DKOD CONNECTION
+### PRE-FLIGHT — DETERMINE REPO AND VERIFY DKOD CONNECTION
 
-**Before ANYTHING else**, verify dkod is connected to the target repo:
+**Before ANYTHING else**, determine the target repository:
+
+1. **Check if the prompt contains `[dkod repo: <owner/repo>]`** — if present, use that
+   exact value as the repo name. This is the authoritative source — it comes from the
+   dkod workspace configuration and is always correct.
+2. **If no tag**, fall back to `git remote get-url origin` in the cwd and extract `owner/repo`.
+3. **NEVER guess the owner from the GitHub username or directory name.**
+   The repo might be under an org (`dkod-io/`) not the user's personal account (`haim-ari/`).
+   Always use the `[dkod repo:]` tag or the git remote — never invent an owner.
+
+Then verify dkod is connected:
 
 ```
 dk_connect(
-  codebase: "<owner/repo>",
+  codebase: "<owner/repo from step above>",
   agent_name: "preflight",
   intent: "Verify dkod connection before starting harness"
 )


### PR DESCRIPTION
## Summary
- **P0 fix:** Generators were ignoring `dk_file_write` conflict_warnings and submitting anyway, causing guaranteed merge failures in Phase 3
- Verified by live testing: `dk_file_write` DOES return `CONFLICT WARNING: test-agent-A is also modifying BoardPage in this file` — the platform mechanism works, generators just weren't treating warnings as blockers

## What was wrong
Conflict_warnings were documented as something to "handle" but not as a hard gate. Generators would see the warning, sometimes attempt a rewrite, but often proceed to dk_submit regardless. The old instructions even said "If warnings persist after 3 rewrites, proceed" — this guaranteed merge failures.

## Changes
1. **Step 3 rewritten:** conflict_warnings are now HARD GATES with explicit resolution flow
2. **Step 4 rewritten:** three-check Pre-Submit Gate (no unresolved conflicts → dk_watch → self-review)
3. **Rule #1:** "NEVER submit with unresolved conflict_warnings" — top priority rule
4. **Submit blocked:** `has_unresolved_conflicts` flag tracks state through the implementation loop
5. **Resolution flow:** dk_watch → dk_file_read → adapt code → dk_file_write → verify clean

## Evidence from testing
```
# Agent A writes BoardPage.tsx and submits
# Agent B writes BoardPage.tsx → gets:
CONFLICT WARNING:
  test-agent-A is also modifying BoardPage in this file
  Your changes may be rejected at SUBMIT time.
```
The platform warns correctly. Generators must listen.

## Test plan
- [ ] Run `/dkh` build and verify generators resolve conflict_warnings before submitting
- [ ] Verify no changesets reach Phase 3 merge with unresolved conflicts
- [ ] Generators that cannot resolve after 3 attempts should report to orchestrator instead of submitting