### PR TITLE
docs: add dkod banner to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
       <img alt="dkod — Agent-native code platform" src="https://raw.githubusercontent.com/dkod-io/dkod-engine/main/.github/assets/banner-dark.svg" width="100%">
     </picture>
   </a>
-</p># dkod harness
+</p>
+
+# dkod harness
 
 Autonomous harness for building complete applications from a single prompt.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
-# dkod harness
+<p align="center">
+  <a href="https://dkod.io">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/dkod-io/dkod-engine/main/.github/assets/banner-dark.svg">
+      <img alt="dkod — Agent-native code platform" src="https://raw.githubusercontent.com/dkod-io/dkod-engine/main/.github/assets/banner-dark.svg" width="100%">
+    </picture>
+  </a>
+</p># dkod harness
 
 Autonomous harness for building complete applications from a single prompt.
 


### PR DESCRIPTION
## Summary
- Adds the official dkod banner to the top of the README
- References the shared banner SVG from dkod-engine (same as dkod-plugin, pi-extension, skills)

## Test plan
- [ ] Verify banner renders on the repo page