### PR TITLE
docs: add dkod banner to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+<p align="center">
+  <a href="https://dkod.io">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/dkod-io/dkod-engine/main/.github/assets/banner-dark.svg">
+      <img alt="dkod — Agent-native code platform" src="https://raw.githubusercontent.com/dkod-io/dkod-engine/main/.github/assets/banner-dark.svg" width="100%">
+    </picture>
+  </a>
+</p>
+
 # dkod harness
 
 Autonomous harness for building complete applications from a single prompt.


### PR DESCRIPTION
## Summary
- Adds the official dkod banner to the top of the README
- Same format as dkod-plugin, pi-extension, and skills repos
- References shared banner SVG from dkod-engine

## Test plan
- [ ] Verify banner renders correctly on the repo page
- [ ] Verify heading and content below are unaffected