### PR TITLE
fix: add tool constraints to planner — prevent dk_submit and write ops

### DIFF
--- a/skills/dkh/agents/planner.md
+++ b/skills/dkh/agents/planner.md
@@ -49,6 +49,24 @@ Turn a vague prompt like "build a task management webapp" into:
    parallel execution via Claude Code agent teams + dkod
 3. **Acceptance criteria** — testable criteria for each unit and for the overall application
 
+## Tool Constraints — MANDATORY
+
+**You are a READ-ONLY agent. You analyze the codebase and produce a plan. You do NOT
+modify code, submit changesets, or trigger any write operations.**
+
+| ALLOWED (use these) | FORBIDDEN (never use these) |
+|---------------------|-------------------------------------|
+| `dk_connect` — open session to read codebase | `dk_submit` — you have nothing to submit |
+| `dk_file_list` — list directory tree | `dk_file_write` — you don't write code |
+| `dk_file_read` — read files | `dk_merge` — orchestrator only |
+| `dk_context` — semantic code search | `dk_approve` — orchestrator only |
+| `dk_close` — close your session when done | `dk_push` — orchestrator only |
+| | `dk_verify` — orchestrator only |
+| | `dk_review` — orchestrator only |
+
+**If you call dk_submit, dk_file_write, or any write tool, it WILL fail and waste time.**
+You are a planner. Your output is TEXT — the plan artifact. Not a changeset.
+
 ## How You Work
 
 ### Step 0: Connect
@@ -381,6 +399,12 @@ if any check fails — save a round trip by catching it yourself:
   and clean"), hex color values, and named font choices (not Arial/Inter/Roboto)
 
 If any check fails, fix the plan before outputting it.
+
+## Final Step: Close Your Session
+
+**After outputting your plan, call `dk_close()` to release your session.**
+The planner session is read-only — there's nothing to submit. Closing it releases the
+session and prevents it from appearing as an orphaned draft changeset.
 
 ## Rules
 

--- a/skills/dkh/agents/planner.md
+++ b/skills/dkh/agents/planner.md
@@ -75,6 +75,9 @@ Call `dk_connect` first — all subsequent dkod tools require an active session:
 - `agent_name`: "harness-planner"
 - `intent`: "Analyze codebase structure and plan parallel build for: <prompt>"
 
+**Save the `session_id` returned by dk_connect — you will pass it to every subsequent
+dk_* call, including dk_close at the end.**
+
 ### Step 1: Discover Existing Specs
 
 Search for existing documentation in the codebase. Check these paths (first match wins):
@@ -402,7 +405,7 @@ If any check fails, fix the plan before outputting it.
 
 ## Final Step: Close Your Session
 
-**After outputting your plan, call `dk_close()` to release your session.**
+**After outputting your plan, call `dk_close(session_id)` to release your session.**
 The planner session is read-only — there's nothing to submit. Closing it releases the
 session and prevents it from appearing as an orphaned draft changeset.
 


### PR DESCRIPTION
## Summary
- Planner called `dk_submit` after analysis (it inherits all tools but had no constraints), causing "no files modified" error and session freeze
- Planner never closed its session, leaving orphaned draft changesets

## Changes
1. Added tool constraints table (same pattern as generator.md) — only read tools allowed
2. Added "Final Step: Close Your Session" — `dk_close()` after outputting the plan

## Test plan
- [ ] Planner completes without calling dk_submit
- [ ] Planner session is closed after plan is produced
- [ ] No orphaned draft changesets from planner sessions