### PR TITLE
fix: enforce OWNS boundary — generators must not create unassigned symbols

### DIFF
--- a/skills/dkh/agents/generator.md
+++ b/skills/dkh/agents/generator.md
@@ -74,7 +74,19 @@ Call `dk_context` with queries relevant to your work unit:
 
 Call `dk_file_read` for any files you need to understand before modifying them.
 
-### Step 3: Implement — CONFLICT_WARNINGS ARE HARD GATES
+### Step 3: Implement — STAY IN YOUR LANE + CONFLICT_WARNINGS ARE HARD GATES
+
+**CRITICAL: You MUST only create/modify symbols listed in your work unit's `OWNS` and
+`Creates` fields.** If you need a symbol that's not in your spec, DO NOT create it —
+another generator owns it. Instead:
+- Define a local/inline type with the shape you need
+- Import from the path the plan specifies for that symbol's owner
+- Use `dk_watch` to see if the owner already created it and use their actual path
+
+**Creating symbols outside your OWNS list is the #1 cause of conflicts.** If your unit
+is "Team Management Page" and your OWNS list doesn't include `useCards`, you MUST NOT
+create `useCards` — even if your implementation seems to need it. Define a local hook
+instead, or wait for the owning generator's version via dk_watch.
 
 **CRITICAL: Every `dk_file_write` response MUST be checked for `conflict_warnings`.
 If conflict_warnings are present, you MUST resolve them BEFORE writing any more files

--- a/skills/dkh/agents/planner.md
+++ b/skills/dkh/agents/planner.md
@@ -247,15 +247,19 @@ ALL units dispatch simultaneously → 6 agents at once
 **Key patterns in this decomposition:**
 
 1. **Every symbol has exactly ONE owner.** The `App` component is owned by Unit 1 and ONLY
-   Unit 1. No other unit writes to `App`. This prevents true conflicts. If two generators
-   both write the `App` component, dkod will detect a true conflict — the planner should
-   prevent this by assigning ownership. (dkod CAN resolve conflicts automatically, but
-   avoiding them is faster.)
+   Unit 1. No other unit writes to `App`. This prevents true conflicts.
 
-2. **Units inline their own types.** Unit 5 (Task list UI) defines its own `Task` interface
-   locally instead of importing from Unit 3. This eliminates any need for sequencing.
+2. **No two units write to the same file.** If `src/store/hooks.ts` has shared hooks,
+   ONE unit owns that file and writes ALL the hooks. Other units that need hooks define
+   them locally in their own files (e.g., `src/features/team/hooks.ts`). Shared files
+   like `store/hooks.ts`, `utils/helpers.ts`, `types/index.ts` are conflict magnets —
+   assign them to exactly one unit or split them into per-feature files.
 
-3. **All 6 units dispatch simultaneously.** 6 agents run at once.
+3. **Units inline their own types AND hooks.** Unit 5 (Task list UI) defines its own
+   `Task` interface AND its own hooks locally instead of importing from shared files.
+   This eliminates cross-unit file conflicts entirely.
+
+4. **All 6 units dispatch simultaneously.** 6 agents run at once.
 
 ### Step 5: Assign Symbol Ownership
 
@@ -400,6 +404,10 @@ if any check fails — save a round trip by catching it yourself:
 - [ ] Overall acceptance criteria exist (app starts, no console errors, responsive, etc.)
 - [ ] **For UI projects**: Design Direction section exists with specific tone (not "modern
   and clean"), hex color values, and named font choices (not Arial/Inter/Roboto)
+- [ ] **No two units create files in the same path.** Check all `Creates:` fields — if two
+  units list the same file path, one of them must be moved to a per-feature file. Shared
+  files (`store/hooks.ts`, `utils/helpers.ts`, `types/index.ts`) are conflict magnets.
+  Either assign to one unit or split into `features/<name>/hooks.ts` per unit.
 
 If any check fails, fix the plan before outputting it.
 


### PR DESCRIPTION
## Summary
- **P0:** Generators were creating symbols outside their OWNS list, causing conflicts with other generators who own those symbols
- Example: unit-6 "Team Management" created useCards in src/store/hooks.ts which unit-2 already owns — 4 symbol conflicts on one file

## Changes
**Generator:** Step 3 hard gate — only create/modify symbols in OWNS and Creates. If you need a symbol not in your spec, define it locally or import via dk_watch.

**Planner:** No two units write to the same file path. Shared files must be split per-feature. Pre-Output Self-Check verifies no duplicate file paths.

## Test plan
- [ ] Generators only create symbols in their OWNS/Creates fields
- [ ] Planner plans have no duplicate file paths across units
- [ ] Zero symbol conflicts at Phase 3 merge