### PR TITLE
fix: restore concurrent file access — same file fine, same symbol not

### DIFF
--- a/skills/dkh/agents/generator.md
+++ b/skills/dkh/agents/generator.md
@@ -74,29 +74,38 @@ Call `dk_context` with queries relevant to your work unit:
 
 Call `dk_file_read` for any files you need to understand before modifying them.
 
-### Step 3: Implement — STAY IN YOUR LANE + CONFLICT_WARNINGS ARE HARD GATES
+### Step 3: Implement — MAXIMUM CONCURRENCY + REAL-TIME COORDINATION
 
-**CRITICAL: You MUST only create/modify symbols listed in your work unit's `OWNS` and
-`Creates` fields.** If you need a symbol that's not in your spec, DO NOT create it —
-another generator owns it. Instead:
-- Define a local/inline type with the shape you need
-- Import from the path the plan specifies for that symbol's owner
-- Use `dk_watch` to see if the owner already created it and use their actual path
+**dkod uses AST-level merging, not line diffing.** This means:
+- **Multiple generators CAN write to the same file** — dkod merges different symbols
+  in the same file automatically. This is a SOFT CONFLICT and resolves on its own.
+- **Multiple generators MUST NOT write to the same symbol** — this is a TRUE CONFLICT
+  that requires manual resolution.
 
-**Creating symbols outside your OWNS list is the #1 cause of conflicts.** If your unit
-is "Team Management Page" and your OWNS list doesn't include `useCards`, you MUST NOT
-create `useCards` — even if your implementation seems to need it. Define a local hook
-instead, or wait for the owning generator's version via dk_watch.
+**You are encouraged to write to any file your implementation needs.** Don't avoid a file
+because another generator might also write to it — that's exactly what dkod handles.
+What matters is SYMBOLS, not files.
 
-**CRITICAL: Every `dk_file_write` response MUST be checked for `conflict_warnings`.
-If conflict_warnings are present, you MUST resolve them BEFORE writing any more files
-and BEFORE calling dk_submit. Submitting with unresolved conflict_warnings is a
-HARNESS VIOLATION — your changeset WILL be rejected at merge and the entire build fails.**
+**HOWEVER: you MUST only create/modify symbols listed in your work unit's `OWNS` and
+`Creates` fields.** If another generator owns a symbol, do NOT overwrite it. Instead:
+- Import from their path (use `dk_watch` to see what they actually created)
+- Define a local type/interface if you just need the shape
+- Add NEW symbols to a shared file — that's fine, dkod merges them
 
-This is the core coordination mechanism of dkod. Multiple generators write to the same
-codebase simultaneously. `dk_file_write` tells you IN REAL TIME if another generator is
-modifying the same symbols. You MUST respond to these warnings — they are not informational,
-they are hard gates.
+**conflict_warnings are your real-time coordination mechanism.** Every `dk_file_write`
+response MUST be checked. If conflict_warnings are present, another generator is modifying
+the SAME SYMBOL (true conflict). You MUST resolve this BEFORE writing more files and
+BEFORE calling dk_submit.
+
+**How conflict resolution works:**
+- **Soft conflict** (different symbols in same file): dkod auto-merges. No warning.
+  No action needed. This is the normal, expected case for parallel generators.
+- **True conflict** (same symbol): `dk_file_write` returns a `CONFLICT WARNING`.
+  You MUST stop, call `dk_watch()`, call `dk_file_read` to see their version, adapt
+  your code to complement theirs, and re-write. Do NOT overwrite their work.
+
+Submitting with unresolved conflict_warnings is a HARNESS VIOLATION — your changeset
+WILL be rejected at merge.
 
 **The implementation loop:**
 

--- a/skills/dkh/agents/planner.md
+++ b/skills/dkh/agents/planner.md
@@ -246,20 +246,21 @@ ALL units dispatch simultaneously → 6 agents at once
 
 **Key patterns in this decomposition:**
 
-1. **Every symbol has exactly ONE owner.** The `App` component is owned by Unit 1 and ONLY
-   Unit 1. No other unit writes to `App`. This prevents true conflicts.
+1. **Every SYMBOL has exactly ONE owner — but files CAN be shared.** dkod uses AST-level
+   merging, not line diffing. Two generators writing DIFFERENT symbols to the same file
+   is perfectly fine — dkod auto-merges them (soft conflict). Two generators writing the
+   SAME symbol is a true conflict that must be avoided via ownership assignment.
 
-2. **No two units write to the same file.** If `src/store/hooks.ts` has shared hooks,
-   ONE unit owns that file and writes ALL the hooks. Other units that need hooks define
-   them locally in their own files (e.g., `src/features/team/hooks.ts`). Shared files
-   like `store/hooks.ts`, `utils/helpers.ts`, `types/index.ts` are conflict magnets —
-   assign them to exactly one unit or split them into per-feature files.
+2. **Multiple units CAN write to the same file.** Unit 2 can add `loginHandler()` to
+   `src/api/routes.ts` while Unit 3 adds `createTask()` to the same file — dkod merges
+   both at the AST level. Don't artificially split files to avoid sharing — that defeats
+   the purpose of dkod's parallel merge capability.
 
-3. **Units inline their own types AND hooks.** Unit 5 (Task list UI) defines its own
-   `Task` interface AND its own hooks locally instead of importing from shared files.
-   This eliminates cross-unit file conflicts entirely.
+3. **Units inline their own types.** Unit 5 (Task list UI) defines its own `Task` interface
+   locally instead of importing from Unit 3. This keeps units independent without requiring
+   sequencing.
 
-4. **All 6 units dispatch simultaneously.** 6 agents run at once.
+4. **All 6 units dispatch simultaneously.** 6 agents run at once. Maximum concurrency.
 
 ### Step 5: Assign Symbol Ownership
 
@@ -404,10 +405,8 @@ if any check fails — save a round trip by catching it yourself:
 - [ ] Overall acceptance criteria exist (app starts, no console errors, responsive, etc.)
 - [ ] **For UI projects**: Design Direction section exists with specific tone (not "modern
   and clean"), hex color values, and named font choices (not Arial/Inter/Roboto)
-- [ ] **No two units create files in the same path.** Check all `Creates:` fields — if two
-  units list the same file path, one of them must be moved to a per-feature file. Shared
-  files (`store/hooks.ts`, `utils/helpers.ts`, `types/index.ts`) are conflict magnets.
-  Either assign to one unit or split into `features/<name>/hooks.ts` per unit.
+- [ ] **No two units own the same SYMBOL** (same file is fine — dkod AST-merges different
+  symbols in the same file automatically). Check OWNS lists for duplicate symbol names.
 
 If any check fails, fix the plan before outputting it.
 


### PR DESCRIPTION
## Summary
Previous PRs overcorrected by restricting generators from writing to the same file. This defeats dkod's core capability: AST-level merging of different symbols in the same file.

## The correct model
- **Same file, different symbols** → soft conflict → dkod auto-merges. **Encouraged.**
- **Same symbol** → true conflict → avoid via ownership, resolve via dk_watch if it happens

## Changes
**Generator Step 3:** Rewritten as "Maximum Concurrency + Real-Time Coordination" — encourages shared file access, clarifies soft vs true conflict handling

**Planner:** Removed "no two units write to the same file" restriction and duplicate file path self-check. Kept duplicate symbol ownership check.

## Test plan
- [ ] Multiple generators write different symbols to the same file → auto-merged
- [ ] True conflicts (same symbol) still detected via conflict_warnings
- [ ] Generators resolve true conflicts via dk_watch + adapt flow