### PR TITLE
feat: switch default model profile to quality (all Opus)

### DIFF
--- a/skills/dkh/SKILL.md
+++ b/skills/dkh/SKILL.md
@@ -79,7 +79,7 @@ without invoking the skill.
 
 ## Model Profiles
 
-**Active profile: balanced**
+**Active profile: quality**
 
 Each agent runs on a model appropriate to its task. The orchestrator reads the active
 profile and passes `model:` on every Agent dispatch call.


### PR DESCRIPTION
## Summary
Switch active profile from `balanced` (Sonnet for generators/evaluators) to `quality` (all Opus).

## Why
Sonnet generators consistently failed to follow the harness workflow:
- Called dk_connect multiple times (fixed with guard, but Sonnet still unreliable)
- Ignored conflict_warnings and submitted anyway
- Created symbols outside OWNS boundaries
- Cost savings from Sonnet are erased by fix rounds from instruction-following failures

The generator workflow now includes conflict_warnings hard gates, dk_watch coordination, OWNS boundary enforcement, pre-submit gates, and 3 report templates. This requires Opus-level instruction adherence.

## Change
One line: `Active profile: balanced` → `Active profile: quality`