### PR TITLE
feat: add effort levels per agent — generators high, planner/evaluator max

### DIFF
--- a/skills/dkh/SKILL.md
+++ b/skills/dkh/SKILL.md
@@ -82,16 +82,20 @@ without invoking the skill.
 **Active profile: quality**
 
 Each agent runs on a model appropriate to its task. The orchestrator reads the active
-profile and passes `model:` on every Agent dispatch call.
+profile and passes `model:` AND `effort:` on every Agent dispatch call.
 
-| Agent | quality | balanced | budget |
-|-------|---------|----------|--------|
-| **Orchestrator**\* | opus | opus | sonnet |
-| **Planner** | opus | opus | sonnet |
-| **Generator** | opus | sonnet | sonnet |
-| **Evaluator** | opus | sonnet | haiku |
+| Agent | quality | balanced | budget | effort |
+|-------|---------|----------|--------|--------|
+| **Orchestrator**\* | opus | opus | sonnet | high |
+| **Planner** | opus | opus | sonnet | max |
+| **Generator** | opus | sonnet | sonnet | high |
+| **Evaluator** | opus | sonnet | haiku | max |
 
 \* The orchestrator model is set by the invoking Claude Code session, not by this table. This row is a recommendation for the session model, not enforced by the harness.
+
+**Effort levels are mandatory.** Planner and Evaluator use `max` (complex reasoning —
+decomposition, scoring). Generator uses `high` (fast execution — file writes, not deep
+analysis). Always pass `effort:` when dispatching agents.
 
 - **quality** — All Opus. Maximum capability. Use for complex or high-stakes builds.
 - **balanced** (default) — Opus for planning and orchestration, Sonnet for implementation

--- a/skills/dkh/agents/orchestrator.md
+++ b/skills/dkh/agents/orchestrator.md
@@ -426,6 +426,7 @@ for each batch in batches:
 // Final evaluator for overall/integration criteria:
 Agent(
   model: <evaluator model from active profile>,
+  effort: <evaluator effort from active profile>,
   prompt: <evaluator.md + spec summary + overall criteria +
            "Test integration across all units. Verify full app end-to-end.
             Server at <SERVER_URL>. Exclusive browser access.

--- a/skills/dkh/agents/orchestrator.md
+++ b/skills/dkh/agents/orchestrator.md
@@ -149,6 +149,7 @@ Spawn a single planner agent:
 Agent(
   subagent_type: "general-purpose",
   model: <planner model from active profile>,
+  effort: <planner effort from active profile>,
   prompt: <inject planner.md instructions + the user's build prompt>,
   description: "Plan parallel build"
 )
@@ -188,6 +189,7 @@ Dispatch ALL generators in `active_units` simultaneously in a single message:
 Agent(
   subagent_type: "general-purpose",
   model: <generator model from active profile>,
+  effort: <generator effort from active profile>,
   prompt: <inject generator.md instructions +
           ONLY these spec sections: Stack, Design Direction, Data Model, API Surface +
           THIS generator's work unit ONLY (not other units) +
@@ -407,6 +409,7 @@ batches = chunk(active_units, batch_size=3)  // last batch may be smaller
 for each batch in batches:
   Agent(
     model: <evaluator model from active profile>,
+    effort: <evaluator effort from active profile>,
     prompt: <evaluator.md +
             ONLY these spec sections: Stack, Design Direction, Data Model, API Surface +
             criteria for ALL units in this batch +


### PR DESCRIPTION
## Summary
- Generators: `effort: high` (fast file writes, not deep analysis)
- Planner/Evaluator: `effort: max` (complex decomposition and scoring)
- Added `effort:` to all Agent dispatch templates in orchestrator.md

## Test plan
- [ ] Generators run faster with high effort
- [ ] Plan/eval quality maintained with max effort