### PR TITLE
fix: reset review_round in Round and REPLAN transitions

### DIFF
--- a/skills/dkh/agents/orchestrator.md
+++ b/skills/dkh/agents/orchestrator.md
@@ -536,6 +536,7 @@ session_map = {}            # wiped — new generators will repopulate
 merged_commit = null        # wiped — new merges will set this
 merge_failures = []         # wiped
 eval_reports = []           # wiped — new evaluators will repopulate
+review_round = {}           # wiped — new generators get fresh review cycles
 # plan remains unchanged
 # unit_attempts remains — carries across rounds (cumulative per unit)
 # blocked_units remains — blocked units are never retried
@@ -567,6 +568,7 @@ session_map = {}            # wiped
 merged_commit = null        # wiped
 merge_failures = []         # wiped
 eval_reports = []           # wiped
+review_round = {}           # wiped — new plan has new units, fresh review cycles
 unit_attempts = {}          # wiped — new plan has new units, old counts are meaningless
 blocked_units = []          # wiped — REPLAN produces new unit IDs; old blocked entries
                             #         would collide with and silently pre-block new units


### PR DESCRIPTION
## Summary
Adds `review_round = {}` to both transition blocks so re-dispatched generators get fresh review cycles.

## Bug
Units that exhausted their 2 review-fix cycles in round 1 would bypass the review gate entirely in round 2+ — even though a brand-new generator agent produced the code. The stale `review_round` counter made the orchestrator think the unit already hit its review cap.

## Fix
Add `review_round = {}` to:
- Round Transition (before re-entering Phase 2)
- REPLAN Transition (before re-entering Phase 1)

## Test plan
- [ ] Verify round 2 generators go through the full review gate (not auto-approved)
- [ ] Verify REPLAN produces fresh review cycles for all new units