### PR TITLE
feat: strict review quality gates — local ≥ 4/5, deep 5/5 required to merge

### DIFF
--- a/skills/dkh/agents/generator.md
+++ b/skills/dkh/agents/generator.md
@@ -259,53 +259,80 @@ findings. You now own the review-fix lifecycle — do NOT just report the score 
 
 **Output status messages so the user can track progress in the dkod-app UI.**
 
-**Run the review-fix loop (max 3 rounds):**
+**Run the review-fix loop (max 10 rounds):**
+
+**═══ MERGE QUALITY GATES — CRITICAL ═══**
+- **Local review score: must be ≥ 4/5** to proceed to deep review
+- **Deep review score: must be 5/5** to exit the loop
+- Changesets that don't meet these thresholds MUST NOT be merged.
+  Keep fixing until you reach 5/5 deep or exhaust 10 rounds.
 
 Before entering the loop, output:
-> Starting review-fix loop (max 3 rounds)
+> Starting review-fix loop (max 10 rounds) — target: local ≥ 4/5, deep 5/5
 
 ```
 round = 1   (the dk_submit you just did)
 
-LOOP while round ≤ 3:
+LOOP while round ≤ 10:
 
-  # Check LOCAL review (inline with dk_submit response)
-  if local review has severity:"error" findings:
-    OUTPUT: "Review-fix round {round}/3: fixing {N} findings (score: {score}/5)"
-    fix the files via dk_file_write
-    # ═══ CONFLICT CHECK — same rule as Step 3 ═══
-    # Every dk_file_write in the review-fix loop MUST be checked for
-    # conflict_warnings. If present, resolve BEFORE re-submitting.
-    # The hard gate applies here too — no exceptions for review fixes.
-    if any dk_file_write returned conflict_warnings → resolve (see Step 3)
+  # ═══ CHECK LOCAL REVIEW (inline with dk_submit response) ═══
+  if local_score < 4 OR local review has severity:"error" findings:
+
+    # STEP A: READ ALL findings — every category, every file, every detail
+    # The review has sections: Convention, Architecture, Logic, Security, etc.
+    # Read EVERY finding, not just the first one or the summary score.
+
+    # STEP B: PLAN all fixes before touching any file
+    # List each finding and what needs to change:
+    #   - Finding 1 (Convention): missing semicolons in X.tsx → add them
+    #   - Finding 2 (Logic): null check missing in Y.ts:42 → add guard
+    #   - Finding 3 (Security): unsanitized input in Z.tsx → escape it
+    OUTPUT: "Review-fix round {round}/10: fixing {N} local findings (score: {local_score}/5)"
+
+    # STEP C: FIX ALL findings across ALL files, THEN submit once
+    # Do NOT submit after each individual fix. Fix everything first.
+    for each file that needs changes:
+      dk_file_write(path, fixed_content)  # may fix multiple findings in one write
+      if conflict_warnings → resolve (see Step 3)
+
+    # STEP D: Submit the complete batch of fixes as ONE changeset
     round += 1
-    if round > 3 → break
+    if round > 10 → break
     dk_submit again
     continue  (re-check local on the new submission)
 
-  # Local is clean — wait for DEEP review
+  # ═══ LOCAL IS CLEAN (≥ 4/5) — CHECK DEEP REVIEW ═══
   dk_watch(filter: "changeset.review.completed")  — blocks until done
   dk_review(changeset_id) → get deep findings + score
 
-  if score ≥ 4 AND no severity:"error" findings:
-    OUTPUT: "Review complete — score: {score}/5 after {round} round(s)"
-    break  (changeset is clean)
+  if deep_score == 5 AND no severity:"error" findings:
+    OUTPUT: "Review complete — local: {local_score}/5, deep: {deep_score}/5 after {round} round(s)"
+    break  (changeset meets quality gates)
 
-  # Deep found issues — fix and re-submit
-  OUTPUT: "Review-fix round {round}/3: fixing {N} deep findings (score: {score}/5)"
-  fix files based on deep findings via dk_file_write
-  # ═══ CONFLICT CHECK — same rule as Step 3 ═══
-  if any dk_file_write returned conflict_warnings → resolve (see Step 3)
+  # Deep score < 5 — same fix process: read ALL, plan ALL, fix ALL, submit ONCE
+  # STEP A: Read ALL deep findings across every section
+  # STEP B: Plan fixes for each finding
+  OUTPUT: "Review-fix round {round}/10: fixing {N} deep findings (deep: {deep_score}/5, target: 5/5)"
+  # STEP C: Fix ALL findings across ALL files
+  for each file that needs changes:
+    dk_file_write(path, fixed_content)
+    if conflict_warnings → resolve (see Step 3)
+  # STEP D: Submit complete batch
   round += 1
-  if round > 3:
-    OUTPUT: "Max review rounds reached — final score: {score}/5"
+  if round > 10:
+    OUTPUT: "Max review rounds reached — local: {local_score}/5, deep: {deep_score}/5"
     break
   dk_submit(intent)
   # loop continues — re-check local before waiting for deep again
 
-# If loop exits at round 1 with a clean score (no findings at all):
-OUTPUT: "Review complete — score: {score}/5 after 1 round"
+# If loop exits at round 1 with perfect scores:
+OUTPUT: "Review complete — local: {local_score}/5, deep: {deep_score}/5 after 1 round"
 ```
+
+**CRITICAL: Fix ALL findings before submitting.** Each submit costs a round. If you fix
+one finding per submit, you'll exhaust your rounds fixing 10 issues one at a time. Instead:
+read all findings → plan all fixes → apply all fixes → submit once. This maximizes the
+score improvement per round.
 
 **These status messages are mandatory.** They appear in the dkod-app activity feed and
 let the user know which review-fix round you're on, how many findings you're fixing, and

--- a/skills/dkh/agents/generator.md
+++ b/skills/dkh/agents/generator.md
@@ -3,7 +3,7 @@ name: dkh:generator
 description: >
   Implements a single work unit from the harness plan via an isolated dkod session. Receives
   a spec, a work unit, and acceptance criteria. Writes code, submits the changeset, then runs
-  a review-fix loop (up to 3 rounds) handling both local and deep code review findings before
+  a review-fix loop (up to 10 rounds) handling both local and deep code review findings before
   reporting completion. Does not merge — the orchestrator handles landing.
 maxTurns: 80
 ---
@@ -336,7 +336,7 @@ score improvement per round.
 
 **These status messages are mandatory.** They appear in the dkod-app activity feed and
 let the user know which review-fix round you're on, how many findings you're fixing, and
-when the loop ends. Always include the round number, total rounds (3), finding count,
+when the loop ends. Always include the round number, total rounds (10), finding count,
 and current score.
 
 **Handling findings:**
@@ -351,7 +351,7 @@ and current score.
 
 ### Step 6: Report
 
-After the review-fix loop exits (clean score or 3 rounds exhausted), report your
+After the review-fix loop exits (clean score or 10 rounds exhausted), report your
 session_id and changeset_id back to the orchestrator and **exit immediately**. Do NOT call
 `dk_merge`, `dk_approve`, `dk_push`, or `dk_verify` — the orchestrator lands all changesets
 in the correct dependency order during Phase 3.
@@ -366,7 +366,7 @@ in the correct dependency order during Phase 3.
 **Session ID:** <from dk_connect response>
 **Changeset ID:** <from dk_submit response>
 **Final review score:** <score after last round>
-**Rounds used:** <1-3>
+**Rounds used:** <1-10>
 **Files modified:** <list>
 **Files created:** <list>
 **Symbols implemented:** <list>

--- a/skills/dkh/agents/orchestrator.md
+++ b/skills/dkh/agents/orchestrator.md
@@ -273,30 +273,39 @@ Before proceeding, verify:
    **After each merge**, output a progress line:
    > Merged changeset `[id]` for unit **[name]**. Progress: **N/M merged.**
 
-#### Review Gate (advisory, max 2 rounds)
+#### Review Gate — CRITICAL (max 10 rounds)
+
+**═══ MERGE QUALITY GATES — NO EXCEPTIONS ═══**
+- **Local review: must be ≥ 4/5** with no severity:"error" findings
+- **Deep review: must be 5/5** with no severity:"error" findings
+- Changesets that don't meet BOTH thresholds MUST NOT be approved or merged.
 
 After dk_verify for each changeset:
 
-1. Call `dk_review(changeset_id)` to get code review results
-2. Check the LOCAL review results (evaluate conditions in order):
-   - **`review_round[unit_id]` >= 2** → max rounds reached, proceed to approve anyway (advisory)
-   - **Score >= 3 AND no "error" severity findings** → proceed to approve
-   - **Score < 3 OR has "error" severity findings** → close the old changeset, then re-dispatch generator with review feedback
-3. **Close the old changeset** before re-dispatch: `dk_close(session_id)` — this releases symbol claims so the new session won't self-conflict.
-4. **Increment `review_round[unit_id]`** by 1, then re-dispatch with payload:
+1. Call `dk_review(changeset_id)` to get code review results (local + deep)
+2. **Check LOCAL review first:**
+   - **Local score < 4 OR has "error" findings** → re-dispatch generator to fix
+   - **Local score ≥ 4 AND no "error" findings** → proceed to check deep review
+3. **Check DEEP review:**
+   - **Deep score == 5 AND no "error" findings** → proceed to approve
+   - **Deep score < 5 OR has "error" findings** → re-dispatch generator to fix
+   - **Deep review not yet complete** → call `dk_watch(filter: "changeset.review.completed")`
+     to wait for it, then `dk_review` again
+4. **`review_round[unit_id]` >= 10** → max rounds reached. If local ≥ 4/5, proceed to
+   approve with the best available changeset. Log a warning with the final scores.
+
+**Re-dispatch flow (when scores don't meet gates):**
+5. **Close the old changeset** before re-dispatch: `dk_close(session_id)`
+6. **Increment `review_round[unit_id]`** by 1, then re-dispatch with payload:
    - Original work unit spec
    - Review findings (copy the dk_review output verbatim as context)
-   - Instruction: "Fix these code review findings, then re-submit via dk_submit"
-5. After generator re-submits with a new session_id and changeset_id:
-   a. **Update `session_map`**: record `session_map[new_changeset_id] = new_session_id` (remove the old entry)
-   b. **Stage** the new changeset_id (do NOT overwrite `changeset_ids` yet — the original verified changeset must remain as fallback)
-   c. **Run `dk_verify`** on the new changeset — re-submitted code must pass lint/type-check/tests
-   d. If dk_verify fails, call `dk_close(session_map[new_changeset_id])` to release the new session's claims, then keep the original changeset_id in `changeset_ids` (skip to approve after max rounds using the last verified changeset)
-   e. If dk_verify passes, **commit** the new changeset_id to `changeset_ids` (replacing the old one), call `dk_review` again, and **return to step 2** to re-evaluate the score and findings
-6. **Max 2 review-fix rounds per unit** — enforced by the first condition in step 2
-7. Track `review_round[unit_id]` separately from eval `round` in state — key by unit_id (stable), NOT changeset_id (changes on re-submit)
-
-Do NOT wait for deep review results — deep review runs asynchronously and is informational only. Only act on local review results which are available immediately after submit.
+   - "Fix these code review findings. Target: local ≥ 4/5, deep 5/5."
+7. After generator re-submits with a new session_id and changeset_id:
+   a. **Update `session_map`**: record the new IDs (remove old entry)
+   b. **Run `dk_verify`** on the new changeset
+   c. If dk_verify fails → keep the original changeset_id as fallback
+   d. If dk_verify passes → commit the new changeset_id, `dk_review` again, return to step 2
+8. Track `review_round[unit_id]` separately from eval `round` — key by unit_id (stable)
 
 Handle conflicts: `dk_resolve` → retry merge.
 

--- a/skills/dkh/agents/orchestrator.md
+++ b/skills/dkh/agents/orchestrator.md
@@ -83,7 +83,7 @@ eval_reports: []            # Set after Phase 4 — MUST EXIST before dk_push
 unit_attempts: {}           # { "unit-id": attempt_count } — incremented each re-dispatch
 blocked_units: []           # Units that exceeded MAX_UNIT_ATTEMPTS (3) — not retried
 replan_count: 0             # Number of REPLANs executed this build (max 1)
-review_round: {}            # { "unit_id": round_count } — per-unit review-fix counter, keyed by unit NOT changeset (max 2)
+review_round: {}            # { "unit_id": round_count } — per-unit review-fix counter, keyed by unit NOT changeset (max 10)
 session_map: {}             # { changeset_id: session_id } — populated from each generator's dk_connect response, needed for dk_close
 ```
 
@@ -266,7 +266,7 @@ Before proceeding, verify:
 **Entry check**: `changeset_ids` must be non-empty.
 
 1. **Verify in PARALLEL** — `dk_verify` ALL changesets simultaneously
-2. **Review Gate** (advisory, max 2 rounds) — see below
+2. **Review Gate** (CRITICAL, max 10 rounds) — see below
 3. **Approve** — `dk_approve` each verified changeset
 4. **Merge sequentially** — `dk_merge` each changeset one at a time. Merge order does not
    matter — all units are independent.
@@ -622,7 +622,7 @@ You decide:
 | Styling | Tailwind CSS unless prompt specifies otherwise |
 | Testing | Vitest for frontend, pytest for backend |
 | Conflict resolution | Auto-resolve non-overlapping. keep_yours for true conflicts. |
-| Eval failures | Re-dispatch generators with feedback. Max 3 rounds. |
+| Eval failures | Re-dispatch generators with feedback. Max 10 review rounds. |
 | Ambiguous requirements | Make a reasonable choice and document it in the spec |
 
 ## PR Description Format


### PR DESCRIPTION
## Summary
Changesets with low review scores were being merged. Now enforced as critical gates.

## Quality Gates (no exceptions)
- **Local review: ≥ 4/5** with no error findings
- **Deep review: 5/5** with no error findings
- **Max 10 rounds** (up from 3) to reach the target
- **Batch fixes:** generators read ALL findings, plan ALL fixes, apply ALL, submit ONCE per round

## Changes
**Generator:** Review-fix loop targets 5/5 deep, ≥ 4/5 local, 10 rounds max. Explicit Steps A-B-C-D per round (read all → plan all → fix all → submit once).

**Orchestrator:** Review gate changed from "advisory" to CRITICAL. Now waits for deep review. Max rounds increased to 10.

## Test plan
- [ ] Generators keep fixing until deep score reaches 5/5
- [ ] Orchestrator blocks merge for changesets with deep < 5/5
- [ ] After 10 rounds, falls back to best available if local ≥ 4/5
- [ ] Generators batch all fixes before submitting (not one fix per submit)