### PR TITLE
fix: add hard exit for review gate 10-round cap when local < 4/5

### DIFF
--- a/skills/dkh/agents/orchestrator.md
+++ b/skills/dkh/agents/orchestrator.md
@@ -291,8 +291,11 @@ After dk_verify for each changeset:
    - **Deep score < 5 OR has "error" findings** → re-dispatch generator to fix
    - **Deep review not yet complete** → call `dk_watch(filter: "changeset.review.completed")`
      to wait for it, then `dk_review` again
-4. **`review_round[unit_id]` >= 10** → max rounds reached. If local ≥ 4/5, proceed to
-   approve with the best available changeset. Log a warning with the final scores.
+4. **`review_round[unit_id]` >= 10** → max rounds reached, hard exit:
+   - If local ≥ 4/5 → proceed to approve with the best available changeset. Log a warning.
+   - If local < 4/5 → skip this unit. Record it in `merge_failures` with reason
+     "review gate exhausted: local score X/5 after 10 rounds". Do NOT approve or merge.
+     The evaluator will catch the missing functionality.
 
 **Re-dispatch flow (when scores don't meet gates):**
 5. **Close the old changeset** before re-dispatch: `dk_close(session_id)`

--- a/skills/dkh/agents/orchestrator.md
+++ b/skills/dkh/agents/orchestrator.md
@@ -293,9 +293,10 @@ After dk_verify for each changeset:
      to wait for it, then `dk_review` again
 4. **`review_round[unit_id]` >= 10** → max rounds reached, hard exit:
    - If local ≥ 4/5 → proceed to approve with the best available changeset. Log a warning.
-   - If local < 4/5 → skip this unit. Record it in `merge_failures` with reason
-     "review gate exhausted: local score X/5 after 10 rounds". Do NOT approve or merge.
-     The evaluator will catch the missing functionality.
+   - If local < 4/5 → `dk_close(session_map[changeset_id])` to release claims, then
+     skip this unit. Record it in `merge_failures` with reason "review gate exhausted:
+     local score X/5 after 10 rounds". Do NOT approve or merge. The evaluator will catch
+     the missing functionality.
 
 **Re-dispatch flow (when scores don't meet gates):**
 5. **Close the old changeset** before re-dispatch: `dk_close(session_id)`


### PR DESCRIPTION
## Summary
Adds a missing else-branch at the review gate's 10-round cap. Without this, when a unit exhausts 10 review-fix cycles with local score still < 4/5, the orchestrator enters an unbounded re-dispatch loop.

## Fix
- local >= 4/5 at cap: approve with best available changeset (existing behavior)
- **local < 4/5 at cap: skip the unit, record in `merge_failures`, let the evaluator catch the gap** (new)

## Test plan
- [ ] Verify unit with persistent low local score gets skipped after 10 rounds
- [ ] Verify skipped unit appears in merge_failures with reason
- [ ] Verify evaluator catches missing functionality from skipped unit