### PR TITLE
fix: remove stale post-loop output that duplicates in-loop status

### DIFF
--- a/skills/dkh/agents/generator.md
+++ b/skills/dkh/agents/generator.md
@@ -255,9 +255,6 @@ LOOP while round ≤ 10:
     break
   dk_submit(intent)
   # loop continues — re-check local before waiting for deep again
-
-# If loop exits at round 1 with perfect scores:
-OUTPUT: "Review complete — local: {local_score}/5, deep: {deep_score}/5 after 1 round"
 ```
 
 **CRITICAL: Fix ALL findings before submitting.** Each submit costs a round. If you fix


### PR DESCRIPTION
## Summary

Removes the post-loop `OUTPUT` block (lines 259-261) from the generator review-fix loop. It was a duplicate of the in-loop output at line 240 and hardcoded "after 1 round" regardless of actual round count.

The in-loop `OUTPUT` at line 240 already handles this correctly with `"after {round} round(s)"`.

Flagged in dkod-io/harness#68 review.