### PR TITLE
fix: file manifest, deep review gate, greenfield guard

### DIFF
--- a/skills/dkh/agents/generator.md
+++ b/skills/dkh/agents/generator.md
@@ -56,8 +56,14 @@ Never call `dk_connect` again — retry `dk_file_write` or `dk_submit` instead.
 ### Step 2: Understand Context
 
 The `dk_connect` response tells you whether the repo is greenfield (0 files) or has
-existing code. For greenfield repos, skip `dk_context` and `dk_file_read` — go straight
-to Step 3. For existing repos, use `dk_context` and `dk_file_read` on files you need.
+existing code.
+
+**Greenfield repos (0 files):** Skip `dk_context` and `dk_file_read` entirely — there are
+no files to read. Go straight to Step 3. Do NOT try to read files that other generators
+will create (e.g., `tsconfig.json`, store files, config files) — they don't exist yet.
+Use the **File Manifest** from the plan to know exact import paths for other units' symbols.
+
+**Existing repos:** Use `dk_context` and `dk_file_read` on files you need.
 
 ### Step 3: Implement — MAXIMUM CONCURRENCY + REAL-TIME COORDINATION
 
@@ -73,9 +79,18 @@ What matters is SYMBOLS, not files.
 
 **HOWEVER: you MUST only create/modify symbols listed in your work unit's `OWNS` and
 `Creates` fields.** If another generator owns a symbol, do NOT overwrite it. Instead:
-- Import from their path (use `dk_watch` to see what they actually created)
+- Import from the **File Manifest** — it has the exact file path and export name for
+  every symbol across all units. Use these paths verbatim. Do NOT guess or invent paths.
 - Define a local type/interface if you just need the shape
 - Add NEW symbols to a shared file — that's fine, dkod merges them
+
+**═══ FILE MANIFEST — USE IT ═══**
+The plan includes a **File Manifest** table mapping every symbol to its exact file path
+and export name. When you need to import a symbol from another unit:
+1. Look up the symbol in the File Manifest
+2. Use the exact `File` path and `Export Name` from the table
+3. Do NOT guess alternative paths or naming conventions
+This is the contract between all generators. Following it guarantees correct imports.
 
 **conflict_warnings are your real-time coordination mechanism.** Every `dk_file_write`
 response MUST be checked. If conflict_warnings are present, another generator is modifying
@@ -103,8 +118,11 @@ for each file in your work unit:
   #    (submitted changesets, review completions, etc.)
   dk_watch()
 
-  # 2. READ the file (if it exists)
-  dk_file_read(path)
+  # 2. READ the file (if it exists in the base commit)
+  #    GREENFIELD GUARD: On greenfield repos (0 files at connect time),
+  #    skip dk_file_read for files you're about to CREATE. They don't exist yet.
+  #    Only dk_file_read files that existed when you connected (existing repos).
+  dk_file_read(path)   # skip if greenfield AND file is new
 
   # 3. WRITE the file
   response = dk_file_write(path, content)

--- a/skills/dkh/agents/orchestrator.md
+++ b/skills/dkh/agents/orchestrator.md
@@ -169,6 +169,9 @@ Before proceeding, verify:
   together (e.g., `run()`, `App.tsx`, `mod.rs`, `index.ts`, `router.ts`) must be listed in
   the plan's Aggregation Symbols table with exactly one owner each. If missing, REJECT.
 - [ ] Design direction established for any UI work
+- [ ] **File Manifest exists.** Every symbol from every unit's OWNS/Creates lists must
+  appear in the File Manifest table with an exact file path and export name. If missing,
+  REJECT — tell the planner to add a File Manifest section.
 
 **If gate fails** → re-run planner with specific feedback, up to **3 attempts**. If Gate 1
 fails 3 times, halt with an error report explaining which checks failed and why the prompt
@@ -194,6 +197,7 @@ Agent(
           ONLY these spec sections: Stack, Design Direction, Data Model, API Surface +
           THIS generator's work unit ONLY (not other units) +
           Aggregation Symbols table (so generators know what NOT to touch) +
+          File Manifest table (so generators know EXACT import paths for all symbols) +
           "CRITICAL: Use dk_connect → dk_file_write → dk_submit ONLY.
            NEVER use Write, Edit, or Bash to create/modify source files.
            Report BOTH session_id AND changeset_id when done.">,
@@ -204,8 +208,8 @@ Agent(
 ```
 
 **Do NOT send every unit's details to every generator.** Each generator only needs:
-the tech stack, design direction, data model, its own unit, and the aggregation table.
-Other units' acceptance criteria are noise that wastes context tokens.
+the tech stack, design direction, data model, its own unit, the aggregation table,
+and the file manifest. Other units' acceptance criteria are noise that wastes context tokens.
 
 Wait for all generators to complete.
 
@@ -292,11 +296,15 @@ After dk_verify for each changeset:
    - **Deep review not yet complete** → call `dk_watch(filter: "changeset.review.completed")`
      to wait for it, then `dk_review` again
 4. **`review_round[unit_id]` >= 10** → max rounds reached, hard exit:
-   - If local ≥ 4/5 → proceed to approve with the best available changeset. Log a warning.
-   - If local < 4/5 → `dk_close(session_map[changeset_id])` to release claims, then
+   - If local ≥ 4/5 **AND** deep ≥ 3/5 → proceed to approve with the best available
+     changeset. Log a warning: "Max review rounds reached — approving with deep {score}/5".
+   - Otherwise → `dk_close(session_map[changeset_id])` to release claims, then
      skip this unit. Record it in `merge_failures` with reason "review gate exhausted:
-     local score X/5 after 10 rounds". Do NOT approve or merge. The evaluator will catch
-     the missing functionality.
+     local {X}/5, deep {Y}/5 after 10 rounds". Do NOT approve or merge. The evaluator
+     will catch the missing functionality.
+   - **NEVER approve a changeset with deep < 3/5.** A deep score of 1/5 or 2/5 indicates
+     critical issues (security vulnerabilities, logic errors). Merging such code wastes
+     more time in later phases than skipping the unit.
 
 **Re-dispatch flow (when scores don't meet gates):**
 5. **Close the old changeset** before re-dispatch: `dk_close(session_id)`

--- a/skills/dkh/agents/planner.md
+++ b/skills/dkh/agents/planner.md
@@ -326,6 +326,46 @@ in separate files owned by their respective units.
 Other units MUST NOT write to files containing aggregation symbols. They write their
 implementations in separate files that the aggregation symbol imports.
 
+### Step 5c: Build the File Manifest
+
+The file manifest is a **complete, structured table** mapping every symbol to its exact
+file path across ALL units. This manifest is sent to EVERY generator so they know exactly
+where to import from — no guessing.
+
+**Why this exists:** Without a shared file manifest, parallel generators must guess import
+paths for symbols owned by other units. Different generators guess differently → broken
+imports across 15+ files → expensive post-merge integration fix. The manifest eliminates
+this class of errors entirely.
+
+**Rules:**
+1. **Every symbol in every unit's OWNS and Creates lists MUST appear in the manifest.**
+2. **File paths are EXACT** — `src/stores/useTaskStore.ts`, not `src/stores/taskStore`.
+3. **Export names are EXACT** — `useTaskStore`, not `taskStore` or `useTaskStoreHook`.
+4. **Follow the stack's conventions** for file paths. If the spec says Zustand, stores go
+   in `src/stores/<storeName>.ts` with `use<Name>Store` as the default export.
+5. **The manifest is the contract.** If a generator needs to import a symbol from another
+   unit, it uses the path and name from the manifest. No alternatives.
+
+**Add this section to your plan output (after Aggregation Symbols):**
+
+```
+## File Manifest
+
+| Symbol | File | Export Name | Owner |
+|--------|------|-------------|-------|
+| App | src/App.tsx | App (default) | WU-01 |
+| router | src/router.tsx | router | WU-01 |
+| useTaskStore | src/stores/useTaskStore.ts | useTaskStore | WU-02 |
+| Task (type) | src/stores/useTaskStore.ts | Task | WU-02 |
+| useProjectStore | src/stores/useProjectStore.ts | useProjectStore | WU-03 |
+| TaskCard | src/components/TaskCard.tsx | TaskCard | WU-04 |
+| BoardPage | src/pages/BoardPage.tsx | BoardPage (default) | WU-05 |
+| ... | ... | ... | ... |
+```
+
+**Every generator receives this table.** When Unit 4 needs to import `useTaskStore`, it
+imports from `src/stores/useTaskStore.ts` — exactly as specified, no guessing.
+
 ### Step 6: Define Acceptance Criteria
 
 For each work unit, define testable criteria the evaluator will check:
@@ -382,6 +422,12 @@ Your output is a single structured artifact:
 |--------|------|-------|---------------|
 | <symbol> | <file> | <owner unit> | <what it imports/registers> |
 
+## File Manifest
+
+| Symbol | File | Export Name | Owner |
+|--------|------|-------------|-------|
+| <symbol> | <exact file path> | <exact export name> | <owner unit> |
+
 ## Dispatch
 All units dispatch simultaneously: [Unit 1, Unit 2, Unit 3, Unit 4, Unit 5, Unit 6]
 
@@ -407,6 +453,8 @@ if any check fails — save a round trip by catching it yourself:
   and clean"), hex color values, and named font choices (not Arial/Inter/Roboto)
 - [ ] **No two units own the same SYMBOL** (same file is fine — dkod AST-merges different
   symbols in the same file automatically). Check OWNS lists for duplicate symbol names.
+- [ ] **File Manifest exists** with every symbol from every unit's OWNS/Creates lists.
+  Every entry has an exact file path and exact export name. No duplicates across units.
 
 If any check fails, fix the plan before outputting it.
 


### PR DESCRIPTION
## Summary

Three targeted fixes addressing the top 3 issues from the 2026-04-11 build session:

- **File Manifest**: Planner produces a structured `Symbol → File → Export Name → Owner` table sent to all generators. Eliminates import path guessing that caused 15+ broken imports and a 46K+ token integration fix agent
- **Deep review gate**: Max-rounds fallback now requires `deep >= 3/5` in addition to `local >= 4/5`. Prevents merging changesets with critical issues (observed: 1/5 deep score merged)
- **Greenfield guard**: Generators on fresh repos skip `dk_file_read` for files being created, preventing wasted tokens on file-not-found errors

## Test plan

- [ ] Run a greenfield parallel build — verify zero `dk_file_read: File not found` errors from generators
- [ ] Verify planner output includes File Manifest section with all symbols
- [ ] Verify Gate 1 rejects plans without File Manifest
- [ ] Verify generators use File Manifest paths for cross-unit imports (no path guessing)
- [ ] Verify max-rounds fallback skips units with deep < 3/5 instead of force-approving
- [ ] Verify post-merge gate check passes without needing integration fix agent