### PR TITLE
fix: deep review 4/5 target + symbol locking design doc

### DIFF
--- a/docs/plans/2026-04-11-symbol-locking-streaming-merge-design.md
+++ b/docs/plans/2026-04-11-symbol-locking-streaming-merge-design.md
@@ -1,0 +1,255 @@
+# Symbol-Level Locking + Streaming Merge
+
+**Date:** 2026-04-11
+**Status:** Approved
+**Scope:** dkod-engine, dk-mcp, dkod-harness
+
+## Problem
+
+The current dkod platform uses advisory conflict detection — `dk_file_write` returns
+`conflict_warnings` that agents can ignore. Conflicts only surface at merge time, after
+agents have spent minutes and thousands of tokens writing code. The harness tries to
+coordinate concurrency through planning (symbol ownership), but:
+
+1. The harness is not the only client — multiple developers with independent agents need
+   the engine itself to enforce safe concurrent access.
+2. Batch-then-merge (all generators submit, then orchestrator merges sequentially) delays
+   conflict detection to the latest possible moment.
+3. Advisory warnings are routinely ignored, causing expensive merge conflicts and
+   post-merge integration fixes (46K+ tokens observed).
+
+## Solution: Symbol-Level Blocking Locks + Streaming Merge
+
+Two coupled changes that make the engine the source of truth for concurrency:
+
+### 1. Symbol-Level Locking (Engine)
+
+Make `SymbolClaimTracker` blocking instead of advisory. When an agent writes a symbol,
+it acquires a lock. Other agents writing the SAME symbol get blocked. Different symbols
+in the same file proceed freely — preserving dkod's core differentiator.
+
+### 2. Streaming Merge (Harness)
+
+Each generator owns its full pipeline: write → submit → verify → review → approve → merge.
+No batch phase. Locks release on merge, unblocking other generators immediately. The
+orchestrator simplifies from 6 phases to 5 — Phase 3 (LAND) collapses into Phase 2 (BUILD).
+
+## Detailed Design
+
+### Engine: SymbolClaimTracker Changes
+
+**File:** `crates/dk-engine/src/conflict/claim_tracker.rs`
+
+Current `record_claim` becomes `acquire_lock`:
+- Returns `Ok(())` if no other session holds the symbol
+- Returns `Err(SymbolLocked { symbol, locked_by, session_id, locked_since })` if another
+  session holds it
+- Same-session re-acquisition always succeeds (idempotent)
+
+Current `check_conflicts` becomes `check_locks` (terminology shift, same logic).
+
+Add `release_locks(session_id)`:
+- Removes all claims for the given session
+- Called on: `dk_merge` success, `dk_close`, session timeout (30 min)
+- Emits `symbol.lock.released` event for each released symbol
+
+### MCP: dk_file_write Response Changes
+
+**File:** `crates/dk-mcp/src/server.rs`
+
+After AST symbol extraction, call `acquire_lock` instead of `record_claim`. New response
+status when lock is held by another session:
+
+```
+{
+  status: "locked",
+  locked_symbols: [
+    {
+      symbol: "useTaskStore",
+      file_path: "src/stores/useTaskStore.ts",
+      locked_by: "generator-unit-2",
+      session_id: "...",
+      locked_since: "2026-04-11T06:30:00Z"
+    }
+  ],
+  message: "Symbols locked by another agent. Call dk_watch(filter: 'symbol.lock.released') to wait, then dk_file_read and retry."
+}
+```
+
+This is a status response, not an error. The write did not happen. The agent should watch
+and retry.
+
+### MCP: New Watch Event
+
+**Event type:** `symbol.lock.released`
+
+```
+{
+  event_type: "symbol.lock.released",
+  symbols: ["useTaskStore", "Task"],
+  file_path: "src/stores/useTaskStore.ts",
+  released_by: "generator-unit-2",
+  session_id: "...",
+  repo_id: "..."
+}
+```
+
+Emitted when `release_locks` is called (merge, close, timeout). Blocked agents watching
+for this event wake up and retry their `dk_file_write`.
+
+### MCP: dk_merge Lock Release
+
+After successful merge in `dk_merge` handler:
+1. Call `release_locks(session_id)` to free all symbol locks
+2. Emit `symbol.lock.released` events for all released symbols
+3. Return `MergeSuccess` as today
+
+Same release in `dk_close` handler (already cleans up, just needs event emission).
+
+### Lock Lifecycle
+
+```
+dk_file_write(symbol X)
+  → acquire_lock(session_id, symbol X)
+  → LOCKED until one of:
+    1. dk_merge succeeds → release_locks → symbol.lock.released event
+    2. dk_close called → release_locks → symbol.lock.released event
+    3. Session timeout (30 min) → release_locks → symbol.lock.released event
+```
+
+### Generator: Self-Merging Pipeline
+
+**File:** `harness/skills/dkh/agents/generator.md`
+
+Current flow:
+```
+write → submit → report(changeset_id) → DONE (orchestrator handles the rest)
+```
+
+New flow:
+```
+write → submit → verify → review-fix loop → approve → merge → report
+```
+
+Tool constraints update:
+- ALLOWED (new): `dk_verify`, `dk_approve`, `dk_merge`, `dk_resolve`
+- These were previously FORBIDDEN (orchestrator-only)
+
+Blocked generator flow:
+```
+dk_file_write("src/stores.ts", useProjectStore)
+  → SYMBOL_LOCKED: useTaskStore locked by generator-unit-2
+  → dk_watch(filter: "symbol.lock.released")    ← blocks until unit-2 merges
+  → dk_file_read("src/stores.ts")               ← sees unit-2's merged code
+  → dk_file_write("src/stores.ts", content)     ← writes alongside unit-2's code
+  → proceeds normally
+```
+
+Generator report changes:
+```
+## Generator Report
+**Status:** merged                     ← was "submitted"
+**Merged Commit:** abc123              ← new field
+**Session ID:** ...
+**Changeset ID:** ...
+**Final review score:** local X/5, deep Y/5
+**Rounds used:** N
+```
+
+New status values:
+- `merged` — successfully merged, lock released
+- `blocked_timeout` — couldn't acquire lock within time budget
+- `review_failed` — couldn't pass review (local < 4/5 or deep < 4/5) after max rounds
+- `conflict_unresolved` — dk_merge conflict couldn't be self-resolved
+
+### Orchestrator: Phase Simplification
+
+**File:** `harness/skills/dkh/agents/orchestrator.md`
+
+Current phases:
+```
+1. PLAN
+2. BUILD (dispatch generators, wait for submit)
+3. LAND (verify → review → approve → merge sequentially)
+4. FILE SYNC + SMOKE TEST
+5. EVAL
+6. SHIP or FIX
+```
+
+New phases:
+```
+1. PLAN
+2. BUILD + LAND (dispatch generators, each self-merges)
+3. FILE SYNC + SMOKE TEST
+4. EVAL
+5. SHIP or FIX
+```
+
+Phase 3 (LAND) is removed entirely. The orchestrator no longer calls `dk_verify`,
+`dk_review`, `dk_approve`, or `dk_merge` — generators do this themselves.
+
+State simplification:
+```
+round: 1
+plan: null
+active_units: []
+merged_units: []           ← replaces changeset_ids
+merge_failures: []
+eval_reports: []
+unit_attempts: {}
+blocked_units: []
+replan_count: 0
+```
+
+Removed state:
+- `changeset_ids` → generators merge themselves, report merged_commit
+- `session_map` → generators close their own sessions
+- `review_round` → generators track their own review rounds
+
+Gate 2 check simplifies to:
+- Every generator reported back
+- Count `merged` vs `blocked_timeout` / `review_failed` / `conflict_unresolved`
+- At least one generator merged successfully
+- Failed units → increment `unit_attempts`, re-dispatch or block
+
+### Review Quality Gates
+
+Unchanged targets (applied by generators internally):
+- **Local review:** must be ≥ 4/5 with no severity:"error"
+- **Deep review:** must be ≥ 4/5 with no severity:"error"
+- **Max rounds:** 10 per generator
+- **Max-rounds fallback:** local ≥ 4/5 AND deep ≥ 3/5 → approve with warning. Otherwise skip.
+
+## What Does NOT Change
+
+- `dk_connect` / `dk_close` / `dk_context` / `dk_file_read` / `dk_file_list` — unchanged
+- `dk_submit` — unchanged (locks already acquired during writes)
+- `dk_push` — unchanged (orchestrator-only, Phase 5)
+- `dk_watch` — unchanged (new event type added, existing filter mechanism works)
+- AST-level merge semantics — unchanged (different symbols = no conflict)
+- Planner — unchanged (symbol ownership + file manifest still valuable for reducing contention)
+- Evaluator — unchanged
+- Session overlay isolation — unchanged (writes still go to overlay, invisible to others)
+
+## New MCP Tools Required
+
+**Zero.** Everything works through existing tools with new response statuses and event types.
+
+## Benefits
+
+1. **Engine enforces concurrency** — no harness required for safety
+2. **Works for any number of developers/agents** — no coordination needed
+3. **Earlier conflict detection** — at write time, not merge time
+4. **Less token waste** — blocked agents wait instead of writing code that will conflict
+5. **Faster unblocking** — streaming merge releases locks as soon as each unit merges
+6. **Simpler harness** — orchestrator drops ~150 lines (Phase 3 + state tracking)
+7. **Greenfield improvement** — early-merging generators make files available to later ones
+
+## Implementation Order
+
+1. **Engine: SymbolClaimTracker** — `acquire_lock` / `release_locks` / `symbol.lock.released` event
+2. **MCP: dk_file_write** — return `SYMBOL_LOCKED` status instead of `conflict_warnings`
+3. **MCP: dk_merge / dk_close** — call `release_locks`, emit events
+4. **Harness: generator.md** — add verify/approve/merge to pipeline, handle SYMBOL_LOCKED
+5. **Harness: orchestrator.md** — remove Phase 3, simplify state
+6. **Harness: dkod-patterns.md** — update reference docs

--- a/skills/dkh/agents/generator.md
+++ b/skills/dkh/agents/generator.md
@@ -2,9 +2,8 @@
 name: dkh:generator
 description: >
   Implements a single work unit from the harness plan via an isolated dkod session. Receives
-  a spec, a work unit, and acceptance criteria. Writes code, submits the changeset, then runs
-  a review-fix loop (up to 10 rounds) handling both local and deep code review findings before
-  reporting completion. Does not merge — the orchestrator handles landing.
+  a spec, a work unit, and acceptance criteria. Writes code, submits, reviews, and merges
+  autonomously — the full pipeline. Reports back with a merged commit hash.
 maxTurns: 80
 ---
 
@@ -15,13 +14,13 @@ application right now, in parallel, each with their own dkod session.
 
 ## Tool Constraints — MANDATORY
 
-**REQUIRED:** `dk_connect` (once), `dk_file_read`, `dk_file_write`, `dk_context`, `dk_submit`, `dk_watch`, `dk_review`
-**FORBIDDEN:** `Write`, `Edit`, `Bash` file redirects, `git` commands, GitHub API tools, `dk_merge`/`dk_approve`/`dk_push`/`dk_verify` (orchestrator-only), second `dk_connect` call
+**REQUIRED:** `dk_connect` (once), `dk_file_read`, `dk_file_write`, `dk_context`, `dk_submit`, `dk_watch`, `dk_review`, `dk_verify`, `dk_approve`, `dk_merge`, `dk_resolve`
+**FORBIDDEN:** `Write`, `Edit`, `Bash` file redirects, `git` commands, GitHub API tools, `dk_push` (orchestrator-only), second `dk_connect` call
 
 Using local tools bypasses dkod's session isolation — other generators see your half-finished
 writes, no changeset is created, and the build breaks. If `dk_connect` fails, STOP and report.
 
-**Workflow: `dk_connect` (ONCE) → `dk_file_read` → `dk_file_write` → `dk_submit` → review-fix loop. Your job ends at submit.**
+**Workflow: `dk_connect` → `dk_file_write` → `dk_submit` → review-fix loop → `dk_approve` → `dk_merge`. You own the full pipeline through merge.**
 
 **Time budget:** The orchestrator has allocated you a time budget (typically 45 minutes).
 If running low on time, submit what you have via `dk_submit` — a partial changeset is
@@ -92,30 +91,36 @@ and export name. When you need to import a symbol from another unit:
 3. Do NOT guess alternative paths or naming conventions
 This is the contract between all generators. Following it guarantees correct imports.
 
-**conflict_warnings are your real-time coordination mechanism.** Every `dk_file_write`
-response MUST be checked. If conflict_warnings are present, another generator is modifying
-the SAME SYMBOL (true conflict). You MUST resolve this BEFORE writing more files and
-BEFORE calling dk_submit.
+**Symbol locking is your real-time coordination mechanism.** Every `dk_file_write`
+response MUST be checked for two conditions:
 
-**How conflict resolution works:**
-- **Soft conflict** (different symbols in same file): dkod auto-merges. No warning.
-  No action needed. This is the normal, expected case for parallel generators.
-- **True conflict** (same symbol): `dk_file_write` returns a `CONFLICT WARNING`.
-  You MUST stop, call `dk_watch()`, call `dk_file_read` to see their version, adapt
-  your code to complement theirs, and re-write. Do NOT overwrite their work.
+1. **SYMBOL_LOCKED** — Another generator holds the lock on a symbol you're trying to write.
+   Your write DID NOT happen. You must wait and retry:
+   ```
+   dk_watch(filter: "symbol.lock.released")   ← blocks until their lock releases (they merged)
+   dk_file_read(path)                          ← read the file with their merged code
+   dk_file_write(path, adapted_content)        ← write your symbols alongside theirs
+   ```
 
-Submitting with unresolved conflict_warnings is a HARNESS VIOLATION — your changeset
-WILL be rejected at merge.
+2. **conflict_warnings** (legacy) — Informational warning that another generator is active
+   on the same symbol. Treat as a signal to call `dk_watch` and coordinate.
+
+**How symbol locking works:**
+- **Different symbols in same file**: No lock contention. Both agents proceed freely.
+  dkod auto-merges at the AST level. This is the normal, expected case.
+- **Same symbol**: `dk_file_write` returns `SYMBOL_LOCKED`. Your write is rejected.
+  Wait for `symbol.lock.released` event, re-read, then write alongside their code.
+
+**Lock lifecycle:** Locks are acquired on `dk_file_write` and released on `dk_merge`,
+`dk_close`, or session timeout. Once the other generator merges, the lock releases and
+you can read their merged code via `dk_file_read`.
 
 **The implementation loop:**
 
 ```
-has_unresolved_conflicts = false
-
 for each file in your work unit:
 
   # 1. Call dk_watch() to check for events from other generators
-  #    (submitted changesets, review completions, etc.)
   dk_watch()
 
   # 2. READ the file (if it exists in the base commit)
@@ -127,37 +132,25 @@ for each file in your work unit:
   # 3. WRITE the file
   response = dk_file_write(path, content)
 
-  # 4. ═══ HARD GATE: CHECK conflict_warnings ═══
+  # 4. ═══ HARD GATE: CHECK RESPONSE ═══
+  if response.status == "locked":
+    # SYMBOL_LOCKED — another generator holds this symbol
+    # Wait for their lock to release (they will merge), then retry
+    dk_watch(filter: "symbol.lock.released")   # blocks until lock releases
+    dk_file_read(path)                          # read their merged code
+    response = dk_file_write(path, adapted_content)  # write alongside theirs
+    # If still locked after 3 retries → report as blocked_timeout
+
   if response contains conflict_warnings:
-    has_unresolved_conflicts = true
-    attempts = 0
-    MAX_ATTEMPTS = 3
-
-    # STOP writing new files. Resolve this conflict FIRST:
-    while response contains conflict_warnings AND attempts < MAX_ATTEMPTS:
-      attempts += 1
-      # a) The warning tells you WHO is modifying the same symbols
-      # b) Call dk_watch() to see their submitted changes
-      # c) Call dk_file_read(path) to get the current merged version
-      # d) Rewrite YOUR file to work alongside THEIR changes
-      #    - Keep their exports/symbols intact
-      #    - Adjust your code to complement, not overwrite
-      #    - Use their import paths and export names
-      # e) response = dk_file_write(path, adapted_content)
-
-    if response contains no conflict_warnings:
-      has_unresolved_conflicts = false   # resolved — continue with remaining files
-    else:
-      # All 3 attempts exhausted — conflict is unresolvable
-      # STOP. Report to orchestrator using Template B (or Template C if
-      # a dk_submit already succeeded in an earlier round).
-      # Do NOT proceed to dk_submit.
+    # Legacy conflict warning — same handling: watch, read, adapt, retry
+    dk_watch()
+    dk_file_read(path)
+    response = dk_file_write(path, adapted_content)
 ```
 
 **═══ SUBMIT GATE ═══**
-**You CANNOT call dk_submit if `has_unresolved_conflicts` is true.**
-Submitting with unresolved conflict_warnings guarantees a merge failure in Phase 3.
-Resolve ALL conflict_warnings first, or report the unresolvable conflict to the orchestrator.
+**You CANNOT call dk_submit if any writes returned SYMBOL_LOCKED and were not resolved.**
+Resolve ALL lock contention first, or report as `blocked_timeout` to the orchestrator.
 
 **Implementation principles:**
 
@@ -199,16 +192,21 @@ Before calling `dk_submit`, verify:
 2. **`dk_watch()` final check** — verify your imports still match what other generators created
 3. **Self-review** — all acceptance criteria addressed, exports match spec
 
-### Step 5: Submit and Review-Fix Loop
+### Step 5: Submit, Review, and Merge — FULL PIPELINE
+
+You own the full pipeline: submit → verify → review-fix → approve → merge. Do NOT
+report back to the orchestrator until you have merged or exhausted all options.
+
+**5a. Submit**
 
 Call `dk_submit` with your work unit title as `intent`. This is **round 1**.
 
-The submit response includes `review_summary` with a local code review score (1-5) and
-findings. You now own the review-fix lifecycle — do NOT just report the score and exit.
+**5b. Verify**
 
-**Output status messages so the user can track progress in the dkod-app UI.**
+Call `dk_verify(changeset_id)` — runs lint, type-check, test, semantic analysis.
+If verify fails, fix the issues and re-submit (counts as a round).
 
-**Run the review-fix loop (max 10 rounds):**
+**5c. Review-Fix Loop (max 10 rounds)**
 
 **═══ MERGE QUALITY GATES — CRITICAL ═══**
 - **Local review score: must be ≥ 4/5** to proceed to deep review
@@ -226,136 +224,119 @@ LOOP while round ≤ 10:
 
   # ═══ CHECK LOCAL REVIEW (inline with dk_submit response) ═══
   if local_score < 4 OR local review has severity:"error" findings:
-
-    # STEP A: READ ALL findings — every category, every file, every detail
-    # The review has sections: Convention, Architecture, Logic, Security, etc.
-    # Read EVERY finding, not just the first one or the summary score.
-
-    # STEP B: PLAN all fixes before touching any file
-    # List each finding and what needs to change:
-    #   - Finding 1 (Convention): missing semicolons in X.tsx → add them
-    #   - Finding 2 (Logic): null check missing in Y.ts:42 → add guard
-    #   - Finding 3 (Security): unsanitized input in Z.tsx → escape it
+    # Read ALL findings, plan ALL fixes, apply ALL fixes, submit ONCE
     OUTPUT: "Review-fix round {round}/10: fixing {N} local findings (score: {local_score}/5)"
-
-    # STEP C: FIX ALL findings across ALL files, THEN submit once
-    # Do NOT submit after each individual fix. Fix everything first.
     for each file that needs changes:
-      dk_file_write(path, fixed_content)  # may fix multiple findings in one write
-      if conflict_warnings → resolve (see Step 3)
-
-    # STEP D: Submit the complete batch of fixes as ONE changeset
+      dk_file_write(path, fixed_content)
     round += 1
     if round > 10 → break
     dk_submit again
-    continue  (re-check local on the new submission)
+    continue
 
   # ═══ LOCAL IS CLEAN (≥ 4/5) — CHECK DEEP REVIEW ═══
-  dk_watch(filter: "changeset.review.completed")  — blocks until done
+  dk_watch(filter: "changeset.review.completed")
   dk_review(changeset_id) → get deep findings + score
 
   if deep_score >= 4 AND no severity:"error" findings:
     OUTPUT: "Review complete — local: {local_score}/5, deep: {deep_score}/5 after {round} round(s)"
-    break  (changeset meets quality gates)
+    break  (proceed to approve + merge)
 
-  # Deep score < 5 — same fix process: read ALL, plan ALL, fix ALL, submit ONCE
-  # STEP A: Read ALL deep findings across every section
-  # STEP B: Plan fixes for each finding
+  # Deep score < 4 — fix all findings, submit once
   OUTPUT: "Review-fix round {round}/10: fixing {N} deep findings (deep: {deep_score}/5, target: 4/5)"
-  # STEP C: Fix ALL findings across ALL files
   for each file that needs changes:
     dk_file_write(path, fixed_content)
-    if conflict_warnings → resolve (see Step 3)
-  # STEP D: Submit complete batch
   round += 1
   if round > 10:
     OUTPUT: "Max review rounds reached — local: {local_score}/5, deep: {deep_score}/5"
     break
   dk_submit(intent)
-  # loop continues — re-check local before waiting for deep again
 ```
 
-**CRITICAL: Fix ALL findings before submitting.** Each submit costs a round. If you fix
-one finding per submit, you'll exhaust your rounds fixing 10 issues one at a time. Instead:
-read all findings → plan all fixes → apply all fixes → submit once. This maximizes the
-score improvement per round.
+**Max-rounds fallback:** If 10 rounds exhausted:
+- If local ≥ 4/5 AND deep ≥ 3/5 → proceed to approve + merge with warning
+- Otherwise → report as `review_failed`, do NOT merge
 
-**These status messages are mandatory.** They appear in the dkod-app activity feed and
-let the user know which review-fix round you're on, how many findings you're fixing, and
-when the loop ends. Always include the round number, total rounds (10), finding count,
-and current score.
+**CRITICAL: Fix ALL findings before submitting.** Each submit costs a round. Read all
+findings → plan all fixes → apply all fixes → submit once.
 
-**Handling findings:**
-- Fix every `severity:"error"` finding — these are blocking (security, logic errors)
-- Fix `severity:"warning"` findings where the suggestion is clear and actionable
-- Do NOT dismiss findings — fix them in code
+**5d. Approve and Merge**
 
-**If submit returns a conflict** (another generator modified a symbol you touched):
-- Read their version from the conflict details
-- Adjust your code to work alongside theirs
-- Re-submit (counts as a round)
+After review gates pass (or max-rounds fallback allows):
+
+```
+dk_approve(changeset_id)
+result = dk_merge(changeset_id, message: "<unit title>")
+
+if result is MergeSuccess:
+  OUTPUT: "Merged — commit: {commit_hash}"
+  # Lock released automatically. Other blocked generators will wake up.
+
+if result is MergeConflict:
+  # Another generator's merge created a conflict with your symbols
+  dk_resolve(resolution: "proceed")   # accept your changes
+  result = dk_merge(changeset_id)     # retry
+  # If still failing after 3 retries → report as conflict_unresolved
+
+if result is OverwriteWarning:
+  dk_merge(changeset_id, force: true)  # your version is authoritative
+```
 
 ### Step 6: Report
 
-After the review-fix loop exits (clean score or 10 rounds exhausted), report your
-session_id and changeset_id back to the orchestrator and **exit immediately**. Do NOT call
-`dk_merge`, `dk_approve`, `dk_push`, or `dk_verify` — the orchestrator lands all changesets
-in the correct dependency order during Phase 3.
+After merge (or failure), report back to the orchestrator and **exit immediately**.
 
-**Use the appropriate report template based on your exit condition:**
-
-**Template A — Successful submit:**
+**Template A — Successfully merged:**
 ```
 ## Generator Report: <unit title>
 
-**Status:** submitted
+**Status:** merged
+**Merged Commit:** <commit_hash from dk_merge response>
 **Session ID:** <from dk_connect response>
 **Changeset ID:** <from dk_submit response>
-**Final review score:** <score after last round>
+**Final review score:** local {X}/5, deep {Y}/5
 **Rounds used:** <1-10>
-**Files modified:** <list>
 **Files created:** <list>
 **Symbols implemented:** <list>
 **Notes:** <any implementation decisions, assumptions, or concerns>
 ```
 
-**Template B — Blocked by unresolved conflict BEFORE first submit (no changeset_id):**
+**Template B — Blocked by symbol lock (timeout):**
 ```
 ## Generator Report: <unit title>
 
-**Status:** conflict_blocked
+**Status:** blocked_timeout
 **Session ID:** <from dk_connect response>
-**Changeset ID:** NONE — dk_submit was NOT called (conflict gate blocked it)
-**Conflicting file:** <path of the file with unresolved conflict_warnings>
-**Conflicting agent:** <agent name from the conflict_warning>
-**Attempts to resolve:** <number of dk_file_write retries attempted>
-**Notes:** <what was tried, why resolution failed>
+**Blocked on symbol:** <symbol name>
+**Locked by:** <agent name>
+**Wait time:** <how long you waited>
+**Notes:** <what happened>
 ```
 
-**Template C — Conflict during review-fix loop AFTER a successful submit:**
+**Template C — Review failed (couldn't meet quality gates):**
 ```
 ## Generator Report: <unit title>
 
-**Status:** conflict_blocked_after_submit
+**Status:** review_failed
 **Session ID:** <from dk_connect response>
-**Changeset ID:** <from the EARLIER successful dk_submit — this is valid, do NOT omit it>
-**Last successful review score:** <score from the round that succeeded>
-**Rounds completed before conflict:** <round number>
-**Conflicting file:** <path of the file with unresolved conflict_warnings>
-**Conflicting agent:** <agent name from the conflict_warning>
-**Notes:** <what was tried, why resolution failed during review-fix>
+**Changeset ID:** <from dk_submit response>
+**Final review score:** local {X}/5, deep {Y}/5
+**Rounds used:** 10
+**Notes:** <which findings couldn't be resolved>
 ```
 
-**CRITICAL: Choose the right template.**
-- Template B: conflict blocked you BEFORE your first dk_submit → no changeset_id exists.
-- Template C: you submitted successfully, then hit a conflict during review-fix → your
-  changeset_id from the earlier submit IS VALID and MUST be reported. The orchestrator
-  will use it in Phase 3 (the earlier submitted version may still be mergeable).
+**Template D — Merge conflict unresolved:**
+```
+## Generator Report: <unit title>
 
-**Both templates MUST include the Session ID.** The orchestrator needs it to call
-`dk_close` on your session and release symbol claims.
+**Status:** conflict_unresolved
+**Session ID:** <from dk_connect response>
+**Changeset ID:** <from dk_submit response>
+**Conflicting file:** <path>
+**Conflicting agent:** <agent name>
+**Notes:** <what was tried>
+```
 
-**After outputting either report, you are DONE. Return control to the orchestrator.**
+**After outputting your report, call `dk_close(session_id)` and exit.**
 
 ## When You're Re-Dispatched (Fix Round)
 
@@ -364,19 +345,15 @@ If the evaluator found failures in your work unit, you'll be re-dispatched with:
 - The evaluator's specific feedback (which criteria failed and why)
 - Screenshots or console output showing the failure
 
-In this case — and ONLY in this case — you are a **new execution** dispatched by the
-orchestrator. You call `dk_connect` once (your one allowed call for this execution):
-1. `dk_connect` (this is your FIRST and ONLY call — you are a fresh sub-agent)
-2. `dk_file_read` the files you previously wrote (they're now in the base after merge)
-3. Fix ONLY the specific issues the evaluator identified
-4. Don't rewrite everything — make targeted fixes
-5. `dk_submit` the fixes
+You are a **new execution** — call `dk_connect` once, read your previously merged files
+via `dk_file_read`, fix ONLY the specific issues, then run the full pipeline again:
+submit → verify → review-fix → approve → merge.
 
 ## Rules
 
-1. **NEVER submit with unresolved conflict_warnings.** See Step 3.
+1. **NEVER submit with unresolved SYMBOL_LOCKED responses.** Wait for lock release first.
 2. **Only modify symbols assigned to your unit.** Import from others, don't overwrite.
-3. **Don't merge.** Only submit. The orchestrator handles landing.
+3. **Own your full pipeline.** Submit, review, approve, merge — then report.
 4. **Be fast.** The build waits for the slowest generator. Parallelize file reads.
 5. **No package installs.** Orchestrator handles deps.
 6. **Bash timeout.** If you must run Bash, always prefix with `timeout 30`.

--- a/skills/dkh/agents/generator.md
+++ b/skills/dkh/agents/generator.md
@@ -212,12 +212,12 @@ findings. You now own the review-fix lifecycle — do NOT just report the score 
 
 **═══ MERGE QUALITY GATES — CRITICAL ═══**
 - **Local review score: must be ≥ 4/5** to proceed to deep review
-- **Deep review score: must be 5/5** to exit the loop
+- **Deep review score: must be ≥ 4/5** to exit the loop
 - Changesets that don't meet these thresholds MUST NOT be merged.
-  Keep fixing until you reach 5/5 deep or exhaust 10 rounds.
+  Keep fixing until you reach 4/5 deep or exhaust 10 rounds.
 
 Before entering the loop, output:
-> Starting review-fix loop (max 10 rounds) — target: local ≥ 4/5, deep 5/5
+> Starting review-fix loop (max 10 rounds) — target: local ≥ 4/5, deep ≥ 4/5
 
 ```
 round = 1   (the dk_submit you just did)
@@ -254,14 +254,14 @@ LOOP while round ≤ 10:
   dk_watch(filter: "changeset.review.completed")  — blocks until done
   dk_review(changeset_id) → get deep findings + score
 
-  if deep_score == 5 AND no severity:"error" findings:
+  if deep_score >= 4 AND no severity:"error" findings:
     OUTPUT: "Review complete — local: {local_score}/5, deep: {deep_score}/5 after {round} round(s)"
     break  (changeset meets quality gates)
 
   # Deep score < 5 — same fix process: read ALL, plan ALL, fix ALL, submit ONCE
   # STEP A: Read ALL deep findings across every section
   # STEP B: Plan fixes for each finding
-  OUTPUT: "Review-fix round {round}/10: fixing {N} deep findings (deep: {deep_score}/5, target: 5/5)"
+  OUTPUT: "Review-fix round {round}/10: fixing {N} deep findings (deep: {deep_score}/5, target: 4/5)"
   # STEP C: Fix ALL findings across ALL files
   for each file that needs changes:
     dk_file_write(path, fixed_content)

--- a/skills/dkh/agents/orchestrator.md
+++ b/skills/dkh/agents/orchestrator.md
@@ -281,7 +281,7 @@ Before proceeding, verify:
 
 **═══ MERGE QUALITY GATES — NO EXCEPTIONS ═══**
 - **Local review: must be ≥ 4/5** with no severity:"error" findings
-- **Deep review: must be 5/5** with no severity:"error" findings
+- **Deep review: must be ≥ 4/5** with no severity:"error" findings
 - Changesets that don't meet BOTH thresholds MUST NOT be approved or merged.
 
 After dk_verify for each changeset:
@@ -291,7 +291,7 @@ After dk_verify for each changeset:
    - **Local score < 4 OR has "error" findings** → re-dispatch generator to fix
    - **Local score ≥ 4 AND no "error" findings** → proceed to check deep review
 3. **Check DEEP review:**
-   - **Deep score == 5 AND no "error" findings** → proceed to approve
+   - **Deep score >= 4 AND no "error" findings** → proceed to approve
    - **Deep score < 5 OR has "error" findings** → re-dispatch generator to fix
    - **Deep review not yet complete** → call `dk_watch(filter: "changeset.review.completed")`
      to wait for it, then `dk_review` again
@@ -311,7 +311,7 @@ After dk_verify for each changeset:
 6. **Increment `review_round[unit_id]`** by 1, then re-dispatch with payload:
    - Original work unit spec
    - Review findings (copy the dk_review output verbatim as context)
-   - "Fix these code review findings. Target: local ≥ 4/5, deep 5/5."
+   - "Fix these code review findings. Target: local ≥ 4/5, deep ≥ 4/5."
 7. After generator re-submits with a new session_id and changeset_id:
    a. **Update `session_map`**: record the new IDs (remove old entry)
    b. **Run `dk_verify`** on the new changeset

--- a/skills/dkh/agents/orchestrator.md
+++ b/skills/dkh/agents/orchestrator.md
@@ -76,15 +76,12 @@ with stale claims.
 round: 1                    # Current round (1, 2, or 3)
 plan: null                  # Set after Phase 1
 active_units: []            # All units in round 1; only failed units in rounds 2+
-changeset_ids: []           # Set after Phase 2 — one per unit in active_units
-merged_commit: null         # Set after Phase 3 — latest commit hash
-merge_failures: []          # Changesets that failed to merge
-eval_reports: []            # Set after Phase 4 — MUST EXIST before dk_push
+merged_units: []            # Units that successfully merged (from generator reports)
+merge_failures: []          # Units that failed to merge/review
+eval_reports: []            # Set after Phase 3 — MUST EXIST before dk_push
 unit_attempts: {}           # { "unit-id": attempt_count } — incremented each re-dispatch
 blocked_units: []           # Units that exceeded MAX_UNIT_ATTEMPTS (3) — not retried
 replan_count: 0             # Number of REPLANs executed this build (max 1)
-review_round: {}            # { "unit_id": round_count } — per-unit review-fix counter, keyed by unit NOT changeset (max 10)
-session_map: {}             # { changeset_id: session_id } — populated from each generator's dk_connect response, needed for dk_close
 ```
 
 ---
@@ -198,9 +195,10 @@ Agent(
           THIS generator's work unit ONLY (not other units) +
           Aggregation Symbols table (so generators know what NOT to touch) +
           File Manifest table (so generators know EXACT import paths for all symbols) +
-          "CRITICAL: Use dk_connect → dk_file_write → dk_submit ONLY.
+          "CRITICAL: Use dk_connect → dk_file_write → dk_submit → dk_verify →
+           dk_approve → dk_merge. You own the full pipeline through merge.
            NEVER use Write, Edit, or Bash to create/modify source files.
-           Report BOTH session_id AND changeset_id when done.">,
+           Report your merged_commit hash when done.">,
   description: "Build: <unit title>",
   name: "generator-<unit-id>"
 )
@@ -211,146 +209,59 @@ Agent(
 the tech stack, design direction, data model, its own unit, the aggregation table,
 and the file manifest. Other units' acceptance criteria are noise that wastes context tokens.
 
-Wait for all generators to complete.
+Wait for all generators to complete. **Generators now own the full pipeline** — each
+generator submits, reviews, approves, and merges its own changeset autonomously.
 
 **As each generator completes**, check its report status:
 
-- **Status: submitted** → record session_id and changeset_id in `session_map`.
-  Output: `Generator **[unit-name]** complete — session [sid], changeset [id], score [X/5]. Progress: N/M done.`
+- **Status: merged** → record in `merged_units` with the merged_commit hash.
+  Output: `Generator **[unit-name]** MERGED — commit [hash], score [X/5]. Progress: N/M done.`
 
-- **Status: conflict_blocked** → the generator could NOT submit due to unresolved
-  conflict_warnings BEFORE its first dk_submit. No changeset_id exists.
-  Record its session_id. **Immediately call `dk_close(session_id)`** to release claims.
-  Output: `Generator **[unit-name]** CONFLICT_BLOCKED — closing session [sid], will re-dispatch. Progress: N/M done.`
+- **Status: blocked_timeout** → the generator couldn't acquire a symbol lock in time.
+  Output: `Generator **[unit-name]** BLOCKED_TIMEOUT — will re-dispatch. Progress: N/M done.`
 
-- **Status: conflict_blocked_after_submit** → the generator submitted successfully but
-  hit an unresolvable conflict during the review-fix loop. It HAS a valid changeset_id
-  from the earlier submit. Record the changeset_id in `changeset_ids`.
-  **Call `dk_close(session_id)`** to release symbol claims from the abandoned review-fix
-  writes — without this, fix-round generators will hit spurious conflicts.
-  **Treat this as a successful submit for Phase 3** — the earlier changeset is valid
-  and may merge cleanly (the conflict was on the review-fix rewrite, not the original).
-  Output: `Generator **[unit-name]** conflict during review-fix — closing session [sid], using earlier changeset [id], score [X/5]. Progress: N/M done.`
+- **Status: review_failed** → the generator couldn't pass review after 10 rounds.
+  Record in `merge_failures`.
+  Output: `Generator **[unit-name]** REVIEW_FAILED — local {X}/5, deep {Y}/5. Progress: N/M done.`
 
-- **No report / crashed** → record whatever session_id is available from the dispatch.
+- **Status: conflict_unresolved** → dk_merge conflict couldn't be self-resolved.
+  Record in `merge_failures`.
+  Output: `Generator **[unit-name]** CONFLICT_UNRESOLVED. Progress: N/M done.`
+
+- **No report / crashed** → record as failure.
 
 **═══ GATE 2 CHECK ═══**
 Before proceeding, verify:
 - [ ] Every generator has reported back
-- [ ] Count generators with `status: submitted` or `status: conflict_blocked_after_submit` (have changeset_id)
-- [ ] Count generators with `status: conflict_blocked` (no changeset_id)
+- [ ] Count `merged` vs `blocked_timeout` / `review_failed` / `conflict_unresolved`
+- [ ] At least one generator merged successfully
 
-**If any generators are conflict_blocked:**
-1. Call `dk_close(session_id)` for each conflict_blocked generator (if not already closed above)
-2. For each conflict_blocked generator:
-   - Increment `unit_attempts[unit_id]`
-   - If `unit_attempts[unit_id] >= 3` → move to `blocked_units`, **remove from `active_units`**, skip re-dispatch
-   - Otherwise → re-dispatch with feedback:
-     "Your previous attempt was blocked by a conflict on <file> with <agent>.
-     That agent's changeset is now submitted. Call dk_watch() first, adapt to their
-     changes, then implement your unit."
-3. If all conflict_blocked generators are now in `blocked_units` → fall through to
-   gate pass with whatever submitted changesets exist (forced-ship with documented gaps)
-4. Otherwise → wait for re-dispatched generators to complete, re-check Gate 2
+**If any generators are blocked_timeout or conflict_unresolved:**
+- Increment `unit_attempts[unit_id]`
+- If `unit_attempts[unit_id] >= 3` → move to `blocked_units`, remove from `active_units`
+- Otherwise → re-dispatch
 
 **If any generators crashed** (no report at all):
-- If they have a recorded session_id → call `dk_close(session_id)` to release claims
-- Re-dispatch. Do NOT proceed until all have submitted.
+- Re-dispatch. Do NOT proceed until all have reported.
 
-**If gate passes** (all generators have status: submitted or conflict_blocked_after_submit, all have changeset_ids):
-→ set `changeset_ids = [...]` and verify `session_map` has an entry for each changeset_id
-  **whose generator reported `submitted`** (conflict_blocked_after_submit sessions are
-  already closed and do not need a session_map entry).
-> **Gate 2 PASSED** — `changeset_ids: [id1, id2, ...]`, `active_units: [N units]`. Proceeding to Phase 3 (Land).
-
----
-
-### PHASE 3 — LAND
-
-**Entry check**: `changeset_ids` must be non-empty.
-
-1. **Verify in PARALLEL** — `dk_verify` ALL changesets simultaneously
-2. **Review Gate** (CRITICAL, max 10 rounds) — see below
-3. **Approve** — `dk_approve` each verified changeset
-4. **Merge sequentially** — `dk_merge` each changeset one at a time. Merge order does not
-   matter — all units are independent.
-   **After each merge**, output a progress line:
-   > Merged changeset `[id]` for unit **[name]**. Progress: **N/M merged.**
-
-#### Review Gate — CRITICAL (max 10 rounds)
-
-**═══ MERGE QUALITY GATES — NO EXCEPTIONS ═══**
-- **Local review: must be ≥ 4/5** with no severity:"error" findings
-- **Deep review: must be ≥ 4/5** with no severity:"error" findings
-- Changesets that don't meet BOTH thresholds MUST NOT be approved or merged.
-
-After dk_verify for each changeset:
-
-1. Call `dk_review(changeset_id)` to get code review results (local + deep)
-2. **Check LOCAL review first:**
-   - **Local score < 4 OR has "error" findings** → re-dispatch generator to fix
-   - **Local score ≥ 4 AND no "error" findings** → proceed to check deep review
-3. **Check DEEP review:**
-   - **Deep score >= 4 AND no "error" findings** → proceed to approve
-   - **Deep score < 5 OR has "error" findings** → re-dispatch generator to fix
-   - **Deep review not yet complete** → call `dk_watch(filter: "changeset.review.completed")`
-     to wait for it, then `dk_review` again
-4. **`review_round[unit_id]` >= 10** → max rounds reached, hard exit:
-   - If local ≥ 4/5 **AND** deep ≥ 3/5 → proceed to approve with the best available
-     changeset. Log a warning: "Max review rounds reached — approving with deep {score}/5".
-   - Otherwise → `dk_close(session_map[changeset_id])` to release claims, then
-     skip this unit. Record it in `merge_failures` with reason "review gate exhausted:
-     local {X}/5, deep {Y}/5 after 10 rounds". Do NOT approve or merge. The evaluator
-     will catch the missing functionality.
-   - **NEVER approve a changeset with deep < 3/5.** A deep score of 1/5 or 2/5 indicates
-     critical issues (security vulnerabilities, logic errors). Merging such code wastes
-     more time in later phases than skipping the unit.
-
-**Re-dispatch flow (when scores don't meet gates):**
-5. **Close the old changeset** before re-dispatch: `dk_close(session_id)`
-6. **Increment `review_round[unit_id]`** by 1, then re-dispatch with payload:
-   - Original work unit spec
-   - Review findings (copy the dk_review output verbatim as context)
-   - "Fix these code review findings. Target: local ≥ 4/5, deep ≥ 4/5."
-7. After generator re-submits with a new session_id and changeset_id:
-   a. **Update `session_map`**: record the new IDs (remove old entry)
-   b. **Run `dk_verify`** on the new changeset
-   c. If dk_verify fails → keep the original changeset_id as fallback
-   d. If dk_verify passes → commit the new changeset_id, `dk_review` again, return to step 2
-8. Track `review_round[unit_id]` separately from eval `round` — key by unit_id (stable)
-
-Handle conflicts: `dk_resolve` → retry merge.
-
-⚠️ **DO NOT dk_push after landing. Shipping is Phase 5 only.**
-
-**═══ GATE 3 CHECK ═══**
-Before proceeding, verify:
-- [ ] Every changeset is either merged OR recorded in `merge_failures`
-- [ ] At least one changeset merged successfully (a `merged_commit` hash exists)
-- [ ] Verification/merge failures are recorded for the eval phase
-
-Partial merge failures are tolerable — the evaluator will catch missing functionality.
-But if ZERO changesets merged, that's a hard block.
-
-**If zero merges** → bulk-close all changesets to release claims, then wipe stale state and re-dispatch:
+**If zero merges** → bulk-close all changesets, wipe state, re-dispatch all generators.
 ```
 Bash: curl -sf -X POST "https://api.dkod.io/api/repos/<owner>/<repo>/changesets/bulk-close" \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $DKOD_API_KEY" \
   -d '{"states": ["draft", "submitted", "approved", "rejected"], "created_before": "'$(date -u +%Y-%m-%dT%H:%M:%SZ)'"}'
 ```
-Then wipe stale state (`changeset_ids = []`, `session_map = {}`, `merged_commit = null`, `merge_failures = []`), then re-dispatch generators with error context.
-**If some merged** → update `merged_commit = <hash>`, record `merge_failures`.
-Output the updated state block:
-> **Gate 3 PASSED** — `merged_commit: [hash]`, `merge_failures: [list or empty]`. Proceeding to Phase 4 (Eval).
 
-Proceed to Phase 4. DO NOT PUSH. DO NOT ASK THE USER.
+**If gate passes** (at least one generator merged):
+> **Gate 2 PASSED** — `merged_units: [N]`, `merge_failures: [list or empty]`. Proceeding to FILE SYNC.
+
+⚠️ **DO NOT dk_push after build. Shipping is Phase 4 only.**
 
 ---
 
 ### FILE SYNC — Get Merged Code Locally
 
-**Entry check**: `merged_commit` must be set. If null → STOP, go back to Phase 3.
+**Entry check**: `merged_units` must be non-empty. If empty → STOP, go back to Phase 2.
 
 Sync the merged code to the local filesystem. **Do NOT use `dk_file_read`** to sync
 files one by one — that wastes 100+ tool calls and can exceed turn limits.
@@ -390,10 +301,10 @@ dk_submit → dk_verify → dk_approve → dk_merge → dk_push branch → git c
 - Kill the dev server
 - Treat ALL units as failed with feedback: "App crashes on startup: <error details>"
 - **Execute Round Transition** (see the "Round Transition" block below): increment `round`,
-  wipe `changeset_ids`, `merged_commit`, `merge_failures`, `eval_reports`
+  wipe `merged_units`, `merge_failures`, `eval_reports`
 - **Check round cap**: if `round >= 3` after incrementing, do NOT re-dispatch.
   Instead, `dk_push` with "app fails to start after 3 rounds" documented. This matches
-  the Phase 5 RETRY round-3 behavior.
+  the Phase 4 RETRY round-3 behavior.
 - Re-dispatch all generators with the crash error as feedback
 - After fix round, re-land, **re-run FILE SYNC** (dk_push branch + git checkout), then re-run smoke test
 
@@ -401,12 +312,11 @@ dk_submit → dk_verify → dk_approve → dk_merge → dk_push branch → git c
 
 ---
 
-### PHASE 4 — EVAL ⚠️ MANDATORY — NEVER SKIP
+### PHASE 3 — EVAL ⚠️ MANDATORY — NEVER SKIP
 
 **Entry check**: Smoke test must have PASSED. Dev server must be running.
 
 **⚠️ STOP AND READ THIS: You are about to evaluate. This is NOT optional.**
-**⚠️ dk_verify (Phase 3) is NOT evaluation. It runs lint/type-check/test.**
 **⚠️ Evaluation means: test with chrome-devtools, score criteria with evidence.**
 **⚠️ You CANNOT call dk_push until eval_reports is populated with REAL evidence.**
 **⚠️ Do NOT fix TypeScript errors, build errors, or lint issues locally with Write/Edit/Bash.**
@@ -477,14 +387,14 @@ Before proceeding, verify:
 - [ ] `eval_reports` is populated
 
 **If gate fails** → re-dispatch missing evaluator batch. Do NOT call dk_push.
-**If gate passes** → set `eval_reports = [...]`. Proceed to Phase 5.
+**If gate passes** → set `eval_reports = [...]`. Proceed to Phase 4.
 
 ---
 
-### PHASE 5 — SHIP or FIX
+### PHASE 4 — SHIP or FIX
 
 **Entry check**: `eval_reports` must be non-empty AND have scores for every criterion.
-If eval_reports is empty → **STOP. YOU SKIPPED PHASE 4. GO BACK.**
+If eval_reports is empty → **STOP. YOU SKIPPED PHASE 3. GO BACK.**
 
 **Verdict aggregation:** Multiple evaluators (per-unit + integration) each emit an
 independent verdict. Aggregate them using the **most severe wins** rule:
@@ -552,20 +462,17 @@ Bash: curl -sf -X POST "https://api.dkod.io/api/repos/<owner>/<repo>/changesets/
 
 round += 1
 active_units = [failed units from eval, EXCLUDING blocked_units]
-changeset_ids = []          # wiped — new generators will repopulate
-session_map = {}            # wiped — new generators will repopulate
-merged_commit = null        # wiped — new merges will set this
+merged_units = []           # wiped — new generators will repopulate
 merge_failures = []         # wiped
 eval_reports = []           # wiped — new evaluators will repopulate
-review_round = {}           # wiped — new generators get fresh review cycles
 # plan remains unchanged
 # unit_attempts remains — carries across rounds (cumulative per unit)
 # blocked_units remains — blocked units are never retried
 # replan_count remains unchanged
 ```
 
-**Do NOT carry stale state.** If `changeset_ids` from round 1 persists into round 2,
-Gate 2 may incorrectly pass. If `eval_reports` from round 1 persists, Gate 4 may
+**Do NOT carry stale state.** If `merged_units` from round 1 persists into round 2,
+Gate 2 may incorrectly pass. If `eval_reports` from round 1 persists, the eval gate may
 incorrectly pass. Wipe them.
 
 ### REPLAN Transition (before re-entering Phase 1):
@@ -584,12 +491,9 @@ Bash: curl -sf -X POST "https://api.dkod.io/api/repos/<owner>/<repo>/changesets/
 replan_count += 1           # increment FIRST — survives the reset
 round = 1                   # restart from round 1
 active_units = []           # wiped — new plan will repopulate
-changeset_ids = []          # wiped
-session_map = {}            # wiped
-merged_commit = null        # wiped
+merged_units = []           # wiped
 merge_failures = []         # wiped
 eval_reports = []           # wiped
-review_round = {}           # wiped — new plan has new units, fresh review cycles
 unit_attempts = {}          # wiped — new plan has new units, old counts are meaningless
 blocked_units = []          # wiped — REPLAN produces new unit IDs; old blocked entries
                             #         would collide with and silently pre-block new units
@@ -615,8 +519,8 @@ After state reset, skip Phase 1 (plan exists). Enter Phase 2 with `active_units`
 - The evaluator's specific failure feedback + evidence
 - Instructions to fix only the failing criteria
 
-Then proceed through Phase 3 (Land) → **FILE SYNC** → Smoke Test → Phase 4 (Eval) → Phase 5 (Ship or Fix).
-**FILE SYNC and Phase 4 are mandatory on EVERY round. Not just round 1.**
+Then proceed through Phase 2 (Build+Land) → **FILE SYNC** → Smoke Test → Phase 3 (Eval) → Phase 4 (Ship or Fix).
+**FILE SYNC and Phase 3 are mandatory on EVERY round. Not just round 1.**
 The sync branch (`dkh/sync-<repo>`) is overwritten on each push — no need to delete between rounds.
 
 ## Decision-Making Rules
@@ -691,5 +595,5 @@ Run this EVERY time before calling dk_push:
 1. "Did the smoke test PASS? If NO → STOP."
 2. "Is `eval_reports` populated with scores for every criterion? If NO → STOP."
 3. "Do the eval reports contain at least one screenshot? If NO → STOP."
-4. "Am I in Phase 5? If NO → STOP."
+4. "Am I in Phase 4? If NO → STOP."
 

--- a/skills/dkh/references/dkod-patterns.md
+++ b/skills/dkh/references/dkod-patterns.md
@@ -56,8 +56,20 @@ dk_file_write(path: "src/api/tasks.ts", content: "<full file content>")
 - Writes go to the session overlay only — invisible to other agents.
 - Always write the COMPLETE file content, not patches.
 - The response includes `detected_changes` — which symbols dkod detected as added/modified.
-- The response may include `conflict_warnings` if another agent has touched the same file.
-  Warnings are informational — they don't block the write.
+- **Symbol locking:** Each symbol you write acquires a lock. If another agent already holds
+  the lock on the same symbol, the write returns `status: "locked"` with details about
+  the lock holder. Your write DID NOT happen — you must wait and retry.
+- Different symbols in the same file do NOT contend — only same-symbol writes are blocked.
+
+**If `status: "locked"` is returned:**
+```
+dk_watch(filter: "symbol.lock.released")   # blocks until their lock releases
+dk_file_read(path)                          # read their merged code
+dk_file_write(path, adapted_content)        # write alongside their code
+```
+
+**Lock lifecycle:** Acquired on `dk_file_write`, held through submit/review/merge,
+released on `dk_merge` success, `dk_close`, or session timeout (30 min).
 
 ### Submit Phase
 
@@ -136,54 +148,47 @@ dk_push(mode: "pr", branch_name: "feat/task-management", pr_title: "...")
 - `"branch"` — push to a branch only
 - `"pr"` — push to branch + open GitHub PR
 
-## The Landing Pipeline
+## Streaming Merge Pipeline
 
-After all generators have submitted, the orchestrator runs the landing pipeline.
+Each generator owns its full pipeline: write → submit → verify → review → approve → merge.
+There is no batch phase — generators merge as soon as they pass review. Symbol locks
+ensure safe concurrent access at the engine level.
 
-### Sequential Landing
+### Generator Self-Merge Flow
 
 ```
-for each changeset:
-  1. dk_verify(changeset_id)
-     → if FAIL: record failures, skip to next
-  2. dk_approve()
-  3. dk_merge(commit_message)
-     → if MergeConflict: resolve and retry
-     → if OverwriteWarning: merge with force: true
-     → if MergeSuccess: continue
+# Each generator runs this autonomously:
+dk_connect(...)
+dk_file_write(...)         # acquires symbol locks
+dk_submit(intent)
+dk_verify(changeset_id)
+# review-fix loop (max 10 rounds)
+dk_approve(changeset_id)
+dk_merge(changeset_id)     # releases symbol locks → unblocks other generators
+dk_close(session_id)
 ```
 
-**Why sequential?** Each `dk_merge` creates a new commit. The next changeset's merge must
-rebase against the new HEAD. dkod handles this automatically (AST-level rebase), but the
-merges must happen one at a time.
+**Why streaming?** Symbol locks are held until merge. If generators submit-and-wait
+for batch merge, locks block other generators indefinitely (deadlock). Streaming merge
+releases locks as soon as each generator finishes, maximizing parallelism.
 
-**Ordering:** Merge order doesn't matter -- all units are independent. dkod auto-rebases
-each changeset against the latest HEAD.
-
-### Conflict Resolution Strategies
+### Conflict Resolution (by generators)
 
 **Auto-merge (no action needed):**
 - Different functions in the same file → dkod auto-merges
 - Different fields added to the same type → dkod auto-merges
 - Same import added by both agents → dkod deduplicates
 
-**Non-overlapping conflict (auto-resolve):**
+**MergeConflict:**
 ```
-dk_resolve(resolution: "proceed")
-→ reconnect and re-submit with updated base
+dk_resolve(resolution: "proceed")   # accept your changes
+dk_merge(changeset_id)              # retry
 ```
 
-**True conflict (orchestrator decides):**
-
-For the autonomous harness, use this decision tree:
-
-1. Is it a conflict between two independent units?
-   → `keep_yours` for the changeset being merged. The other changeset will auto-rebase
-   on its turn. If it can't, the evaluator will catch the integration issue.
-
-2. Is it a setup/scaffolding conflict (package.json, config files)?
-   → `keep_yours` with `force: true`. These are usually additive (both agents adding
-   dependencies or config entries) and dkod will merge them.
+**OverwriteWarning:**
+```
+dk_merge(changeset_id, force: true)  # your version is authoritative
+```
 
 ### Post-Landing Verification
 


### PR DESCRIPTION
## Summary

- **Deep review target lowered from 5/5 to 4/5** across generator and orchestrator. 5/5 was too strict — generators burned excessive review-fix rounds chasing info-level findings. Max-rounds fallback still requires deep >= 3/5
- **Symbol-level locking + streaming merge design doc** — approved design for engine-level concurrency enforcement and self-merging generators

## Test plan

- [ ] Verify generators target deep >= 4/5 (not 5/5) in review-fix loop
- [ ] Verify orchestrator accepts deep >= 4/5 for approval
- [ ] Verify max-rounds fallback still skips units with deep < 3/5
- [ ] Review design doc for completeness before engine implementation