### PR TITLE
feat: prefer Playwright CLI and DESIGN.md with graceful fallbacks

### DIFF
--- a/skills/dkh/SKILL.md
+++ b/skills/dkh/SKILL.md
@@ -5,13 +5,16 @@ description: >
   Autonomous harness for building complete applications from a single prompt. Uses dkod for
   parallel agent execution with AST-level semantic merging. Orchestrates a Planner that decomposes
   work by symbol into parallel units, N Generator agents that implement simultaneously via isolated
-  dkod sessions, and a skeptical Evaluator that tests the live result via chrome-devtools and
-  dk_verify. Fully autonomous — zero user interaction from prompt to working, tested PR.
+  dkod sessions, and a skeptical Evaluator that tests the live result via Playwright CLI (preferred)
+  or chrome-devtools MCP (fallback), plus dk_verify. Fully autonomous — zero user interaction
+  from prompt to working, tested PR.
   Use this skill whenever the user provides a build prompt ("build a...", "create a...",
   "make a...") or invokes /dkh.
 compatibility: >
-  Requires dkod MCP server (claude mcp add --transport http dkod https://api.dkod.io/mcp)
-  and chrome-devtools MCP for evaluation. Works with Claude Code and Opus 4.6.
+  Requires dkod MCP server (claude mcp add --transport http dkod https://api.dkod.io/mcp).
+  Evaluation: Playwright CLI (preferred) or chrome-devtools MCP (fallback).
+  Design: DESIGN.md from awesome-design-md (preferred) or frontend-design skill (fallback).
+  Works with Claude Code and Opus 4.6.
 ---
 
 # dkod Harness — Autonomous Parallel Build System
@@ -99,24 +102,51 @@ Before starting, verify these are available:
 
 1. **dkod MCP tools**: `dk_connect`, `dk_context`, `dk_file_write`, `dk_submit`, `dk_verify`,
    `dk_review`, `dk_approve`, `dk_merge`, `dk_push`, `dk_status`, `dk_watch`
-2. **chrome-devtools MCP**: `navigate_page`, `take_screenshot`, `click`, `evaluate_script`,
-   `list_console_messages`, `lighthouse_audit`
-3. **frontend-design skill**: Required for any project with UI. Generators MUST invoke
-   `Skill(skill: "frontend-design")` before implementing UI components. The planner MUST
-   include a Design Direction section in the spec. The evaluator MUST score design quality.
+
+2. **Browser testing (pick one — Playwright preferred):**
+   - **Playwright CLI** (preferred): Check with `timeout 10 npx playwright --version`. If
+     available, evaluators and smoke tests use Playwright CLI commands (`npx playwright
+     screenshot`, `npx playwright test`, etc.) instead of chrome-devtools MCP. Playwright
+     runs headless by default, needs no MCP server, and produces deterministic results.
+   - **chrome-devtools MCP** (fallback): `navigate_page`, `take_screenshot`, `click`,
+     `evaluate_script`, `list_console_messages`, `lighthouse_audit`. Used only if Playwright
+     is not installed.
+   - If NEITHER is available, evaluation falls to `dk_verify` + code review (no live UI testing).
+     Output: `"⚠️ dkod recommends using Playwright CLI for browser testing: npm i -D playwright @playwright/test && npx playwright install chromium"`
+
+3. **Design system (pick one — DESIGN.md preferred):**
+   - **DESIGN.md** (preferred): A design system file in the project root, sourced from
+     [awesome-design-md](https://github.com/VoltAgent/awesome-design-md). If present, it
+     becomes the authoritative design reference — the planner incorporates it into the spec,
+     generators follow it directly (no skill invocation needed), and the evaluator scores
+     against it. This produces more distinctive, brand-aligned UI than the generic skill.
+   - **frontend-design skill** (fallback): If no DESIGN.md exists, generators invoke
+     `Skill(skill: "frontend-design")` before implementing UI components. The planner still
+     generates a Design Direction section in the spec. The evaluator still scores design quality.
+     Output: `"💡 dkod recommends using a DESIGN.md file for higher-quality frontend design. Browse options at https://github.com/VoltAgent/awesome-design-md"`
+   - If NEITHER is available, generators follow the planner's Design Direction section manually.
+
+**Detection flow (run once during PRE-FLIGHT):**
+```
+# 1. Detect Playwright
+HAS_PLAYWRIGHT = false
+timeout 10 npx playwright --version 2>/dev/null && HAS_PLAYWRIGHT = true
+
+# 2. Detect DESIGN.md
+HAS_DESIGN_MD = false
+[ -f DESIGN.md ] && HAS_DESIGN_MD = true
+
+# Pass both flags to all agent dispatches:
+# - Planner: HAS_DESIGN_MD
+# - Generators: HAS_DESIGN_MD
+# - Evaluators: HAS_PLAYWRIGHT
+# - Smoke test: HAS_PLAYWRIGHT
+```
 
 If dkod is missing, guide installation:
 ```bash
 claude mcp add --transport http dkod https://api.dkod.io/mcp
 ```
-
-If chrome-devtools is missing, note that evaluation will be limited to `dk_verify` + code
-review (no live UI testing).
-
-If frontend-design skill is missing, generators MUST still follow the Design Direction section
-from the spec manually. The planner's Design Direction section provides all the creative
-direction needed — generators should treat it as their design brief and apply it directly
-without invoking the skill.
 
 ## Model Profiles
 

--- a/skills/dkh/SKILL.md
+++ b/skills/dkh/SKILL.md
@@ -104,15 +104,17 @@ Before starting, verify these are available:
    `dk_review`, `dk_approve`, `dk_merge`, `dk_push`, `dk_status`, `dk_watch`
 
 2. **Browser testing (pick one — Playwright preferred):**
-   - **Playwright CLI** (preferred): Check with `timeout 10 npx playwright --version`. If
-     available, evaluators and smoke tests use Playwright CLI commands (`npx playwright
-     screenshot`, `npx playwright test`, etc.) instead of chrome-devtools MCP. Playwright
-     runs headless by default, needs no MCP server, and produces deterministic results.
+   - **Playwright** (preferred): Check with `timeout 10 npx playwright --version`. Uses
+     `@playwright/test` as a library via inline Node.js scripts (`node -e "..."`) for
+     navigation, screenshots, clicks, form fills, console checks, and JS evaluation.
+     Runs headless by default, needs no MCP server, produces deterministic results.
+     CLI subcommands (`npx playwright test`, `npx playwright codegen`) available for
+     structured test runs.
    - **chrome-devtools MCP** (fallback): `navigate_page`, `take_screenshot`, `click`,
      `evaluate_script`, `list_console_messages`, `lighthouse_audit`. Used only if Playwright
      is not installed.
    - If NEITHER is available, evaluation falls to `dk_verify` + code review (no live UI testing).
-     Output: `"⚠️ dkod recommends using Playwright CLI for browser testing: npm i -D playwright @playwright/test && npx playwright install chromium"`
+     Output: `"⚠️ dkod recommends using Playwright for browser testing: npm i -D @playwright/test && npx playwright install chromium"`
 
 3. **Design system (pick one — DESIGN.md preferred):**
    - **DESIGN.md** (preferred): A design system file in the project root, sourced from
@@ -127,14 +129,14 @@ Before starting, verify these are available:
    - If NEITHER is available, generators follow the planner's Design Direction section manually.
 
 **Detection flow (run once during PRE-FLIGHT):**
-```
-# 1. Detect Playwright
-HAS_PLAYWRIGHT = false
-timeout 10 npx playwright --version 2>/dev/null && HAS_PLAYWRIGHT = true
+```bash
+# 1. Detect Playwright (@playwright/test)
+HAS_PLAYWRIGHT=false
+timeout 10 npx playwright --version 2>/dev/null && HAS_PLAYWRIGHT=true
 
-# 2. Detect DESIGN.md
-HAS_DESIGN_MD = false
-[ -f DESIGN.md ] && HAS_DESIGN_MD = true
+# 2. Detect DESIGN.md (check all paths the planner searches)
+HAS_DESIGN_MD=false
+( [ -f DESIGN.md ] || [ -f design.md ] || [ -f docs/DESIGN.md ] || [ -f docs/design.md ] ) && HAS_DESIGN_MD=true
 
 # Pass both flags to all agent dispatches:
 # - Planner: HAS_DESIGN_MD

--- a/skills/dkh/agents/evaluator.md
+++ b/skills/dkh/agents/evaluator.md
@@ -20,15 +20,17 @@ the criteria you receive (per-unit or integration).
 The orchestrator passes `HAS_PLAYWRIGHT` in your dispatch prompt. This determines which
 browser testing approach you use:
 
-**If `HAS_PLAYWRIGHT = true` → Use Playwright CLI (preferred):**
-Playwright runs headless Chrome via CLI commands. It is more reliable, deterministic, and
-does not require an MCP server. All browser interactions in Steps 5a-5c below show both
-Playwright and chrome-devtools equivalents — use the Playwright versions.
+**If `HAS_PLAYWRIGHT = true` → Use Playwright (preferred):**
+Playwright runs headless Chrome via inline Node.js scripts (`node -e "..."`). Use
+`require('playwright')` to launch browsers, navigate, screenshot, click, fill, and
+evaluate JS. More reliable and deterministic than MCP — no browser extension needed.
+All browser interactions in Steps 5a-5c below show both Playwright and chrome-devtools
+equivalents — use the Playwright versions.
 
 **If `HAS_PLAYWRIGHT = false` → Use chrome-devtools MCP (fallback):**
 Use the chrome-devtools MCP tools as documented in the fallback sections below.
 Output once at the start of your report:
-`"💡 dkod recommends using Playwright CLI for more reliable browser testing: npm i -D playwright @playwright/test && npx playwright install chromium"`
+`"💡 dkod recommends using Playwright for more reliable browser testing: npm i -D @playwright/test && npx playwright install chromium"`
 
 **Time budget:** The orchestrator injects your time budget in the dispatch prompt (typically
 30 minutes per unit in your batch — e.g., 60 min for a 2-unit batch, 90 min for 3-unit).
@@ -79,33 +81,62 @@ Otherwise, start the dev server yourself and track `I_STARTED_SERVER = true`.
 
 **After EVERY navigation, verify loading completes.**
 
-#### If `HAS_PLAYWRIGHT = true` — Playwright CLI
+#### If `HAS_PLAYWRIGHT = true` — Playwright
 
-Use Bash commands with `timeout 30` prefix for all Playwright operations:
+Use inline Node.js scripts via Bash with `timeout 30` prefix. All scripts use
+`require('playwright')` to launch a headless browser.
 
 1. **Navigate + screenshot:**
    ```bash
-   timeout 30 npx playwright screenshot --wait-for-selector="body" <URL> screenshot-initial.png
+   timeout 30 node -e "
+     const { chromium } = require('playwright');
+     (async () => {
+       const browser = await chromium.launch();
+       const page = await browser.newPage();
+       await page.goto('<URL>', { waitUntil: 'networkidle' });
+       await page.screenshot({ path: 'screenshot-initial.png' });
+       await browser.close();
+     })();
+   "
    ```
 
 2. **Detect loading indicators:**
    ```bash
-   timeout 30 npx playwright evaluate <URL> "(() => {
-     const loadingEls = [...document.querySelectorAll('[aria-busy=\"true\"], [class*=\"spinner\"], [class*=\"loading\"], [class*=\"skeleton\"]')]
-       .filter(el => getComputedStyle(el).display !== 'none');
-     const loadingText = [...document.querySelectorAll('*')].filter(el =>
-       el.children.length === 0 && /^(loading|please wait)/i.test(el.textContent.trim()));
-     return { isLoading: loadingEls.length + loadingText.length > 0, count: loadingEls.length + loadingText.length };
-   })()"
+   timeout 30 node -e "
+     const { chromium } = require('playwright');
+     (async () => {
+       const browser = await chromium.launch();
+       const page = await browser.newPage();
+       await page.goto('<URL>', { waitUntil: 'networkidle' });
+       const result = await page.evaluate(() => {
+         const loadingEls = [...document.querySelectorAll('[aria-busy=\"true\"], [class*=\"spinner\"], [class*=\"loading\"], [class*=\"skeleton\"]')]
+           .filter(el => getComputedStyle(el).display !== 'none');
+         const loadingText = [...document.querySelectorAll('*')].filter(el =>
+           el.children.length === 0 && /^(loading|please wait)/i.test(el.textContent.trim()));
+         return { isLoading: loadingEls.length + loadingText.length > 0, count: loadingEls.length + loadingText.length };
+       });
+       console.log(JSON.stringify(result));
+       await browser.close();
+     })();
+   "
    ```
    If loading, wait 10s and recheck. Still loading → **FAIL (3/10 max)**.
 
 3. **Final screenshot** (must show real content):
    ```bash
-   timeout 30 npx playwright screenshot <URL> screenshot-final.png
+   timeout 30 node -e "
+     const { chromium } = require('playwright');
+     (async () => {
+       const browser = await chromium.launch();
+       const page = await browser.newPage();
+       await page.goto('<URL>', { waitUntil: 'networkidle' });
+       await page.screenshot({ path: 'screenshot-final.png' });
+       await browser.close();
+     })();
+   "
    ```
 
-4. **Check console errors** — run a Playwright script via Bash:
+4. **Check console errors:**
    ```bash
    timeout 30 node -e "
      const { chromium } = require('playwright');
@@ -122,12 +153,12 @@ Use Bash commands with `timeout 30` prefix for all Playwright operations:
    ```
 
 **Playwright testing patterns:**
-- **UI criteria:** screenshot → Playwright script (navigate, click, fill, assert) → screenshot
-- **API criteria:** `curl` via Bash or Playwright `page.evaluate(fetch(...))`
+- **UI criteria:** screenshot → script (navigate, click, fill, assert) → screenshot
+- **API criteria:** `curl` via Bash or `page.evaluate(() => fetch(...))`
 - **Error handling:** submit empty forms, navigate to invalid routes, send bad API requests
-- **Responsive:** `timeout 30 npx playwright screenshot --viewport-size="375,812" <URL> mobile.png`
-  then `timeout 30 npx playwright screenshot --viewport-size="1440,900" <URL> desktop.png`
-- **Interactions** — use inline Playwright scripts for click/fill/type:
+- **Responsive:** use `browser.newContext({ viewport: { width: 375, height: 812 } })` for
+  mobile, `{ width: 1440, height: 900 }` for desktop — screenshot each
+- **Interactions:**
   ```bash
   timeout 30 node -e "
     const { chromium } = require('playwright');
@@ -194,7 +225,7 @@ weakest link determines the score.
 Beyond acceptance criteria, audit ALL interactive elements on every page. A button that
 renders but does nothing on click is broken — even if no criterion mentions it.
 
-#### If `HAS_PLAYWRIGHT = true` — Playwright
+#### If `HAS_PLAYWRIGHT = true`
 
 1. **Discover elements** via Playwright script:
    ```bash

--- a/skills/dkh/agents/evaluator.md
+++ b/skills/dkh/agents/evaluator.md
@@ -1,9 +1,10 @@
 ---
 name: dkh:evaluator
 description: >
-  Adversarial evaluator that tests the merged application via chrome-devtools MCP and dk_verify.
-  Skeptical by design — defaults to FAIL unless proven PASS with evidence. Scores each acceptance
-  criterion, provides specific actionable feedback, and produces a structured eval report.
+  Adversarial evaluator that tests the merged application via Playwright CLI (preferred) or
+  chrome-devtools MCP (fallback), plus dk_verify. Skeptical by design — defaults to FAIL
+  unless proven PASS with evidence. Scores each acceptance criterion, provides specific
+  actionable feedback, and produces a structured eval report.
 maxTurns: 120
 ---
 
@@ -11,8 +12,23 @@ You are a dkod harness evaluator. You are an adversary — your job is to break 
 generators built. Test the merged application against acceptance criteria and produce an
 honest, evidence-based evaluation.
 
-You run SEQUENTIALLY with exclusive chrome-devtools access. Your scope is defined by
+You run SEQUENTIALLY with exclusive browser access. Your scope is defined by
 the criteria you receive (per-unit or integration).
+
+## Browser Testing Tool Selection
+
+The orchestrator passes `HAS_PLAYWRIGHT` in your dispatch prompt. This determines which
+browser testing approach you use:
+
+**If `HAS_PLAYWRIGHT = true` → Use Playwright CLI (preferred):**
+Playwright runs headless Chrome via CLI commands. It is more reliable, deterministic, and
+does not require an MCP server. All browser interactions in Steps 5a-5c below show both
+Playwright and chrome-devtools equivalents — use the Playwright versions.
+
+**If `HAS_PLAYWRIGHT = false` → Use chrome-devtools MCP (fallback):**
+Use the chrome-devtools MCP tools as documented in the fallback sections below.
+Output once at the start of your report:
+`"💡 dkod recommends using Playwright CLI for more reliable browser testing: npm i -D playwright @playwright/test && npx playwright install chromium"`
 
 **Time budget:** The orchestrator injects your time budget in the dispatch prompt (typically
 30 minutes per unit in your batch — e.g., 60 min for a 2-unit batch, 90 min for 3-unit).
@@ -59,9 +75,77 @@ Call `dk_review` — score < 3 or "error" severity findings are criterion failur
 If the orchestrator provided a server URL, **skip this step** — use the provided URL.
 Otherwise, start the dev server yourself and track `I_STARTED_SERVER = true`.
 
-### Step 5a: Test via Chrome DevTools
+### Step 5a: Test via Browser
 
-**After EVERY navigation, verify loading completes:**
+**After EVERY navigation, verify loading completes.**
+
+#### If `HAS_PLAYWRIGHT = true` — Playwright CLI
+
+Use Bash commands with `timeout 30` prefix for all Playwright operations:
+
+1. **Navigate + screenshot:**
+   ```bash
+   timeout 30 npx playwright screenshot --wait-for-selector="body" <URL> screenshot-initial.png
+   ```
+
+2. **Detect loading indicators:**
+   ```bash
+   timeout 30 npx playwright evaluate <URL> "(() => {
+     const loadingEls = [...document.querySelectorAll('[aria-busy=\"true\"], [class*=\"spinner\"], [class*=\"loading\"], [class*=\"skeleton\"]')]
+       .filter(el => getComputedStyle(el).display !== 'none');
+     const loadingText = [...document.querySelectorAll('*')].filter(el =>
+       el.children.length === 0 && /^(loading|please wait)/i.test(el.textContent.trim()));
+     return { isLoading: loadingEls.length + loadingText.length > 0, count: loadingEls.length + loadingText.length };
+   })()"
+   ```
+   If loading, wait 10s and recheck. Still loading → **FAIL (3/10 max)**.
+
+3. **Final screenshot** (must show real content):
+   ```bash
+   timeout 30 npx playwright screenshot <URL> screenshot-final.png
+   ```
+
+4. **Check console errors** — run a Playwright script via Bash:
+   ```bash
+   timeout 30 node -e "
+     const { chromium } = require('playwright');
+     (async () => {
+       const browser = await chromium.launch();
+       const page = await browser.newPage();
+       const errors = [];
+       page.on('console', msg => { if (msg.type() === 'error') errors.push(msg.text()); });
+       await page.goto('<URL>', { waitUntil: 'networkidle' });
+       await browser.close();
+       console.log(JSON.stringify({ errors, count: errors.length }));
+     })();
+   "
+   ```
+
+**Playwright testing patterns:**
+- **UI criteria:** screenshot → Playwright script (navigate, click, fill, assert) → screenshot
+- **API criteria:** `curl` via Bash or Playwright `page.evaluate(fetch(...))`
+- **Error handling:** submit empty forms, navigate to invalid routes, send bad API requests
+- **Responsive:** `timeout 30 npx playwright screenshot --viewport-size="375,812" <URL> mobile.png`
+  then `timeout 30 npx playwright screenshot --viewport-size="1440,900" <URL> desktop.png`
+- **Interactions** — use inline Playwright scripts for click/fill/type:
+  ```bash
+  timeout 30 node -e "
+    const { chromium } = require('playwright');
+    (async () => {
+      const browser = await chromium.launch();
+      const page = await browser.newPage();
+      await page.goto('<URL>', { waitUntil: 'networkidle' });
+      await page.click('button:has-text(\"Submit\")');
+      await page.waitForTimeout(2000);
+      await page.screenshot({ path: 'after-click.png' });
+      console.log(JSON.stringify({ url: page.url(), title: await page.title() }));
+      await browser.close();
+    })();
+  "
+  ```
+
+#### If `HAS_PLAYWRIGHT = false` — chrome-devtools MCP (fallback)
+
 1. `take_screenshot` — initial state
 2. Detect loading indicators with `evaluate_script`:
    ```
@@ -86,9 +170,14 @@ Otherwise, start the dev server yourself and track `I_STARTED_SERVER = true`.
 
 ### Step 5b: Design Quality Audit (MANDATORY for UI)
 
-Score the implementation against the spec's **Design Direction** section:
-1. **Typography** — custom fonts loaded? Clear hierarchy? (`evaluate_script` → check computed font-family)
-2. **Color & Theme** — matches spec palette? Cohesive? (`evaluate_script` → sample CSS custom properties)
+Score the implementation against the spec's **Design Direction** section. If the spec
+references a DESIGN.md source, read it with `dk_file_read("DESIGN.md")` and verify the
+implementation matches its exact tokens (colors, fonts, spacing). DESIGN.md compliance
+is stricter — the design system defines specific values, not just a direction.
+
+**Check these (use Playwright scripts or `evaluate_script` depending on `HAS_PLAYWRIGHT`):**
+1. **Typography** — custom fonts loaded? Clear hierarchy? Check computed font-family
+2. **Color & Theme** — matches spec palette / DESIGN.md tokens? Cohesive? Sample CSS custom properties
 3. **Layout & Spacing** — intentional composition? Consistent spacing?
 4. **Visual polish** — backgrounds with depth? Hover states? Transitions? Empty state handling?
 
@@ -104,6 +193,38 @@ weakest link determines the score.
 
 Beyond acceptance criteria, audit ALL interactive elements on every page. A button that
 renders but does nothing on click is broken — even if no criterion mentions it.
+
+#### If `HAS_PLAYWRIGHT = true` — Playwright
+
+1. **Discover elements** via Playwright script:
+   ```bash
+   timeout 30 node -e "
+     const { chromium } = require('playwright');
+     (async () => {
+       const browser = await chromium.launch();
+       const page = await browser.newPage();
+       await page.goto('<URL>', { waitUntil: 'networkidle' });
+       const elements = await page.evaluate(() => {
+         return [...document.querySelectorAll('button, [role=\"button\"], a[href], [onclick], [tabindex=\"0\"]')]
+           .filter(el => { const s = getComputedStyle(el); return s.display !== 'none' && s.visibility !== 'hidden' && el.offsetParent !== null; })
+           .filter(el => !el.disabled && el.getAttribute('aria-disabled') !== 'true')
+           .filter(el => !el.href || el.href.startsWith(location.origin) || el.href.startsWith('#'))
+           .map(el => ({ tag: el.tagName, text: (el.textContent||'').trim().slice(0,60), id: el.id||null }));
+       });
+       console.log(JSON.stringify(elements));
+       await browser.close();
+     })();
+   "
+   ```
+
+2. **Test each element** via Playwright script: screenshot before → click → wait 5s →
+   screenshot after. Compare URL/title/content before and after.
+   Identical before/after → element is dead → **3/10 max**.
+
+3. **Judgment calls:** Always test buttons with text, nav links, form submits. Skip decorative
+   elements, disabled buttons, data-entry inputs. Sample 2-3 from identical lists.
+
+#### If `HAS_PLAYWRIGHT = false` — chrome-devtools MCP
 
 1. **Discover elements** with `evaluate_script`:
    ```
@@ -189,5 +310,5 @@ If the orchestrator provided the server, do NOT kill it.
 4. **Test edge cases.** Empty inputs, long strings, special characters, back button.
 5. **Surgical fix hints.** Specific file, function, line — not "rewrite the system."
 6. **Be honest about PASS.** Adversarial means rigorous, not unfair. Score 8-10 when earned.
-7. **Clean up processes.** Kill dev servers if you started them.
-8. **Fallback without chrome-devtools:** Use curl/Bash. Note in report that live UI testing was skipped.
+7. **Clean up processes.** Kill dev servers if you started them. Close Playwright browsers.
+8. **Fallback without Playwright or chrome-devtools:** Use curl/Bash. Note in report that live UI testing was skipped.

--- a/skills/dkh/agents/evaluator.md
+++ b/skills/dkh/agents/evaluator.md
@@ -201,10 +201,12 @@ Use inline Node.js scripts via Bash with `timeout 30` prefix. All scripts use
 
 ### Step 5b: Design Quality Audit (MANDATORY for UI)
 
-Score the implementation against the spec's **Design Direction** section. If the spec
-references a DESIGN.md source, read it with `dk_file_read("DESIGN.md")` and verify the
-implementation matches its exact tokens (colors, fonts, spacing). DESIGN.md compliance
-is stricter — the design system defines specific values, not just a direction.
+Score the implementation against the spec's **Design Direction** section. If the spec's
+Design Direction has a **Source** line referencing awesome-design-md (e.g.,
+`Source: docs/DESIGN.md (awesome-design-md)`), read that exact path with `dk_file_read`
+and verify the implementation matches its tokens. If no path is in the spec, try:
+`DESIGN.md`, `design.md`, `docs/DESIGN.md`, `docs/design.md`. Design system compliance
+is stricter — it defines specific values, not just a direction.
 
 **Check these (use Playwright scripts or `evaluate_script` depending on `HAS_PLAYWRIGHT`):**
 1. **Typography** — custom fonts loaded? Clear hierarchy? Check computed font-family

--- a/skills/dkh/agents/generator.md
+++ b/skills/dkh/agents/generator.md
@@ -167,13 +167,15 @@ Resolve ALL lock contention first, or report as `blocked_timeout` to the orchest
 MUST follow the design system before writing code.** This is not optional.
 
 **Option A — DESIGN.md exists (preferred):**
-If the spec's Design Direction says "Source: DESIGN.md (awesome-design-md)" or if a
-`DESIGN.md` file exists in the project root, read it with `dk_file_read("DESIGN.md")`.
+If the spec's Design Direction has a **Source** line referencing awesome-design-md (e.g.,
+`Source: docs/DESIGN.md (awesome-design-md)`), read that exact path with `dk_file_read`.
+If no path is in the spec but `HAS_DESIGN_MD = true`, try these paths in order:
+`DESIGN.md`, `design.md`, `docs/DESIGN.md`, `docs/design.md` — use the first that exists.
 This file IS your design system — follow it directly:
-- Extract color tokens, typography, spacing, component patterns from DESIGN.md
+- Extract color tokens, typography, spacing, component patterns from the design system file
 - Apply them consistently to every component you build
-- Use the exact hex values, font families, and spacing scales defined in DESIGN.md
-- Do NOT invoke the `frontend-design` skill — DESIGN.md supersedes it
+- Use the exact hex values, font families, and spacing scales defined in the file
+- Do NOT invoke the `frontend-design` skill — the design system supersedes it
 
 **Option B — No DESIGN.md (fallback to frontend-design skill):**
 If no DESIGN.md exists, invoke the `frontend-design` skill:

--- a/skills/dkh/agents/generator.md
+++ b/skills/dkh/agents/generator.md
@@ -164,16 +164,26 @@ Resolve ALL lock contention first, or report as `blocked_timeout` to the orchest
 ### Frontend Design — MANDATORY for UI work units
 
 **If your work unit creates or modifies any UI (components, pages, layouts, styling), you
-MUST invoke the `frontend-design` skill before writing code.** This is not optional.
+MUST follow the design system before writing code.** This is not optional.
 
+**Option A — DESIGN.md exists (preferred):**
+If the spec's Design Direction says "Source: DESIGN.md (awesome-design-md)" or if a
+`DESIGN.md` file exists in the project root, read it with `dk_file_read("DESIGN.md")`.
+This file IS your design system — follow it directly:
+- Extract color tokens, typography, spacing, component patterns from DESIGN.md
+- Apply them consistently to every component you build
+- Use the exact hex values, font families, and spacing scales defined in DESIGN.md
+- Do NOT invoke the `frontend-design` skill — DESIGN.md supersedes it
+
+**Option B — No DESIGN.md (fallback to frontend-design skill):**
+If no DESIGN.md exists, invoke the `frontend-design` skill:
 ```
 Skill(skill: "frontend-design")
 ```
 
-After invoking the skill, follow its guidelines when implementing your unit:
+**In both cases, follow these principles:**
 - Read the **Design Direction** section from the specification — it defines the aesthetic
   tone, color palette, typography, and spatial composition for the entire project
-- Apply the `frontend-design` skill's principles to every component you build
 - Choose distinctive, characterful fonts — NEVER use generic defaults (Arial, Inter, Roboto)
 - Use CSS variables for color/spacing consistency across all your components
 - Add meaningful motion: page transitions, hover states, loading animations
@@ -181,8 +191,7 @@ After invoking the skill, follow its guidelines when implementing your unit:
 - Every UI element should feel intentionally designed for the project's context
 
 **The evaluator will score design quality.** Generic "AI slop" aesthetics (purple gradients
-on white, cookie-cutter cards, Inter font, no personality) will FAIL evaluation. The
-`frontend-design` skill exists to prevent this — use it.
+on white, cookie-cutter cards, Inter font, no personality) will FAIL evaluation.
 
 ### Step 4: Pre-Submit Gate — MANDATORY
 

--- a/skills/dkh/agents/orchestrator.md
+++ b/skills/dkh/agents/orchestrator.md
@@ -134,13 +134,14 @@ Bash: curl -sf -X POST "https://api.dkod.io/api/repos/<owner>/<repo>/changesets/
 Detect preferred tools and store flags for all subsequent agent dispatches:
 
 ```bash
-# 1. Detect Playwright CLI
+# 1. Detect Playwright (@playwright/test)
 HAS_PLAYWRIGHT=false
 timeout 10 npx playwright --version 2>/dev/null && HAS_PLAYWRIGHT=true
 
 # 2. Detect DESIGN.md (awesome-design-md design system)
+# Check all paths the planner searches: DESIGN.md, design.md, docs/DESIGN.md, docs/design.md
 HAS_DESIGN_MD=false
-[ -f DESIGN.md ] && HAS_DESIGN_MD=true
+( [ -f DESIGN.md ] || [ -f design.md ] || [ -f docs/DESIGN.md ] || [ -f docs/design.md ] ) && HAS_DESIGN_MD=true
 ```
 
 **Output detection results to the user:**
@@ -151,7 +152,7 @@ HAS_DESIGN_MD=false
 ```
 
 **If `HAS_PLAYWRIGHT = false`:**
-Output: `"💡 dkod recommends using Playwright CLI for more reliable browser testing: npm i -D playwright @playwright/test && npx playwright install chromium"`
+Output: `"💡 dkod recommends using Playwright for more reliable browser testing: npm i -D @playwright/test && npx playwright install chromium"`
 
 **If `HAS_DESIGN_MD = false` and the project has UI:**
 Output: `"💡 dkod recommends using a DESIGN.md file for higher-quality frontend design. Browse options at https://github.com/VoltAgent/awesome-design-md"`
@@ -324,7 +325,16 @@ tokens testing a broken app. Fix the build first.
 
    **If `HAS_PLAYWRIGHT = true`:**
    ```bash
-   timeout 30 npx playwright screenshot --wait-for-selector="body" <APP_URL> smoke-test.png
+   timeout 30 node -e "
+     const { chromium } = require('playwright');
+     (async () => {
+       const browser = await chromium.launch();
+       const page = await browser.newPage();
+       await page.goto('<APP_URL>', { waitUntil: 'networkidle' });
+       await page.screenshot({ path: 'smoke-test.png' });
+       await browser.close();
+     })();
+   "
    ```
    Then read `smoke-test.png` to confirm it shows real content.
 

--- a/skills/dkh/agents/orchestrator.md
+++ b/skills/dkh/agents/orchestrator.md
@@ -129,6 +129,39 @@ Bash: curl -sf -X POST "https://api.dkod.io/api/repos/<owner>/<repo>/changesets/
   -d '{"states": ["draft", "submitted", "approved", "rejected"], "created_before": "'$(date -u +%Y-%m-%dT%H:%M:%SZ)'"}'
 ```
 
+### Tool Detection — Run Once During PRE-FLIGHT
+
+Detect preferred tools and store flags for all subsequent agent dispatches:
+
+```bash
+# 1. Detect Playwright CLI
+HAS_PLAYWRIGHT=false
+timeout 10 npx playwright --version 2>/dev/null && HAS_PLAYWRIGHT=true
+
+# 2. Detect DESIGN.md (awesome-design-md design system)
+HAS_DESIGN_MD=false
+[ -f DESIGN.md ] && HAS_DESIGN_MD=true
+```
+
+**Output detection results to the user:**
+```
+🔍 Tool detection:
+  Playwright CLI: {HAS_PLAYWRIGHT ? "✅ found" : "❌ not found — will use chrome-devtools MCP"}
+  DESIGN.md:      {HAS_DESIGN_MD ? "✅ found — using as design system" : "❌ not found — will use frontend-design skill"}
+```
+
+**If `HAS_PLAYWRIGHT = false`:**
+Output: `"💡 dkod recommends using Playwright CLI for more reliable browser testing: npm i -D playwright @playwright/test && npx playwright install chromium"`
+
+**If `HAS_DESIGN_MD = false` and the project has UI:**
+Output: `"💡 dkod recommends using a DESIGN.md file for higher-quality frontend design. Browse options at https://github.com/VoltAgent/awesome-design-md"`
+
+**Pass these flags to every agent dispatch:**
+- Planner: include `HAS_DESIGN_MD` in the prompt
+- Generators: include `HAS_DESIGN_MD` in the prompt
+- Evaluators: include `HAS_PLAYWRIGHT` in the prompt
+- Smoke test: use `HAS_PLAYWRIGHT` to choose browser tool
+
 Proceed to Phase 1.
 
 ---
@@ -147,7 +180,8 @@ Agent(
   subagent_type: "general-purpose",
   model: <planner model from active profile>,
   effort: <planner effort from active profile>,
-  prompt: <inject planner.md instructions + the user's build prompt>,
+  prompt: <inject planner.md instructions + the user's build prompt +
+          "HAS_DESIGN_MD = <true|false>.">,
   description: "Plan parallel build"
 )
 ```
@@ -195,7 +229,8 @@ Agent(
           THIS generator's work unit ONLY (not other units) +
           Aggregation Symbols table (so generators know what NOT to touch) +
           File Manifest table (so generators know EXACT import paths for all symbols) +
-          "CRITICAL: Use dk_connect → dk_file_write → dk_submit → dk_verify →
+          "HAS_DESIGN_MD = <true|false>.
+           CRITICAL: Use dk_connect → dk_file_write → dk_submit → dk_verify →
            dk_approve → dk_merge. You own the full pipeline through merge.
            NEVER use Write, Edit, or Bash to create/modify source files.
            Report your merged_commit hash when done.">,
@@ -207,7 +242,8 @@ Agent(
 
 **Do NOT send every unit's details to every generator.** Each generator only needs:
 the tech stack, design direction, data model, its own unit, the aggregation table,
-and the file manifest. Other units' acceptance criteria are noise that wastes context tokens.
+the file manifest, and the `HAS_DESIGN_MD` flag. Other units' acceptance criteria are
+noise that wastes context tokens.
 
 Wait for all generators to complete. **Generators now own the full pipeline** — each
 generator submits, reviews, approves, and merges its own changeset autonomously.
@@ -284,9 +320,39 @@ tokens testing a broken app. Fix the build first.
 1. Install dependencies: `bun install`
 2. Start the dev server: `bun run dev`
 3. Wait for the server to be ready (check the port)
-4. **Verify the app loads** — use chrome-devtools `navigate_page` + `take_screenshot` to
-   confirm the app renders something (not a blank page, not an error overlay, not a crash)
-5. **Check the console** — use `list_console_messages` to check for fatal errors
+4. **Verify the app loads** — use the detected browser tool:
+
+   **If `HAS_PLAYWRIGHT = true`:**
+   ```bash
+   timeout 30 npx playwright screenshot --wait-for-selector="body" <APP_URL> smoke-test.png
+   ```
+   Then read `smoke-test.png` to confirm it shows real content.
+
+   **If `HAS_PLAYWRIGHT = false`:**
+   Use chrome-devtools `navigate_page` + `take_screenshot` to confirm the app renders
+   something (not a blank page, not an error overlay, not a crash).
+
+5. **Check the console** — check for fatal errors:
+
+   **If `HAS_PLAYWRIGHT = true`:**
+   ```bash
+   timeout 30 node -e "
+     const { chromium } = require('playwright');
+     (async () => {
+       const browser = await chromium.launch();
+       const page = await browser.newPage();
+       const errors = [];
+       page.on('console', msg => { if (msg.type() === 'error') errors.push(msg.text()); });
+       await page.goto('<APP_URL>', { waitUntil: 'networkidle' });
+       await browser.close();
+       if (errors.length) { console.log('ERRORS:', JSON.stringify(errors)); process.exit(1); }
+       console.log('No fatal console errors');
+     })();
+   "
+   ```
+
+   **If `HAS_PLAYWRIGHT = false`:**
+   Use `list_console_messages` to check for fatal errors.
 
 **═══ SMOKE TEST GATE ═══**
 - [ ] Dev server started without crashing
@@ -324,12 +390,15 @@ dk_submit → dk_verify → dk_approve → dk_merge → dk_push branch → git c
 
 The dev server is already running from the smoke test. Do NOT start another one.
 
-Dispatch evaluators **sequentially** (one at a time) — they share a single chrome-devtools
-browser session. Do NOT instruct evaluators to start their own dev server.
+Dispatch evaluators **sequentially** (one at a time) — they share a single browser session
+(Playwright or chrome-devtools). Do NOT instruct evaluators to start their own dev server.
 
 **Batch units to minimize dispatches:** Group 2-3 work units per evaluator when units are
 related or test similar areas. Each evaluator receives the combined criteria for its batch
 and scores all of them. The final evaluator always handles overall/integration criteria.
+
+**CRITICAL: Pass `HAS_PLAYWRIGHT` to every evaluator dispatch.** This tells the evaluator
+which browser tool to use.
 
 ```
 // Group active_units into batches of 2-3 units each. Never batch_size=1 unless
@@ -346,6 +415,7 @@ for each batch in batches:
             criteria for ALL units in this batch +
             "The dev server is already running at <SERVER_URL>.
              Do NOT start another dev server. You have exclusive browser access.
+             HAS_PLAYWRIGHT = <true|false>.
              Score every criterion for all units in your batch.
              Time budget: <30 × len(batch)> minutes.">,
     description: "Eval: <batch unit titles>",
@@ -361,6 +431,7 @@ Agent(
   prompt: <evaluator.md + spec summary + overall criteria +
            "Test integration across all units. Verify full app end-to-end.
             Server at <SERVER_URL>. Exclusive browser access.
+            HAS_PLAYWRIGHT = <true|false>.
             Time budget: 30 minutes.">,
   description: "Eval: integration",
   name: "evaluator-integration"
@@ -369,14 +440,14 @@ Agent(
 
 Wait for the integration evaluator to complete. Then stop the dev server.
 
-**Why batch?** Each evaluator dispatch includes the full evaluator.md instructions (~190 lines).
+**Why batch?** Each evaluator dispatch includes the full evaluator.md instructions (~250 lines).
 Batching 2-3 units per evaluator cuts the number of dispatches (and thus instruction
 repetitions) by 50-66%, saving significant context tokens. The evaluator still tests every
 criterion — it just tests more criteria per session.
 
-**Why sequential?** Evaluators share chrome-devtools. Parallel evaluators would race on
-navigate/screenshot/click, corrupting evidence. This is the ONE phase where serialization
-is mandatory.
+**Why sequential?** Evaluators share browser state (Playwright or chrome-devtools). Parallel
+evaluators would race on navigate/screenshot/click, corrupting evidence. This is the ONE
+phase where serialization is mandatory.
 
 **═══ GATE 4 CHECK ═══**
 Before proceeding, verify:

--- a/skills/dkh/agents/planner.md
+++ b/skills/dkh/agents/planner.md
@@ -106,12 +106,15 @@ Use `dk_file_list` to check which files exist, then `dk_file_read` to read match
 - This is the common case for greenfield projects
 
 **If a DESIGN.md file is found (or `HAS_DESIGN_MD = true` from orchestrator):**
-- Read it — this is an awesome-design-md design system document
+- Try these paths in order: `DESIGN.md`, `design.md`, `docs/DESIGN.md`, `docs/design.md`
+- Read the first match — this is an awesome-design-md design system document
 - It becomes the **authoritative design reference** for the project
 - Use it to populate the Design Direction section (see Step 3) instead of inventing one
 - Extract: color palette, typography, spacing, component styles, tone/aesthetic
-- Note in the spec: "Design system sourced from DESIGN.md (awesome-design-md)"
-- Generators will follow DESIGN.md directly — no frontend-design skill needed
+- **CRITICAL: Note the ACTUAL resolved path in the spec** — e.g., if found at `docs/DESIGN.md`,
+  write: `"Design system sourced from docs/DESIGN.md (awesome-design-md)"`. Generators and
+  evaluators will use this exact path to read the file. Do NOT hardcode `DESIGN.md`.
+- Generators will follow the design system directly — no frontend-design skill needed
 
 **If no DESIGN.md exists:**
 - Generate the Design Direction section from scratch (current behavior)
@@ -182,14 +185,14 @@ Produce a specification that covers:
 ## Design Direction — MANDATORY for any project with UI
 
 **If DESIGN.md exists** (from awesome-design-md):
-<Summarize the key design tokens from DESIGN.md — colors, typography, spacing, component
-patterns, tone. Reference it as the authority: "See DESIGN.md for complete design system."
-Generators will read DESIGN.md directly and do NOT need the frontend-design skill.>
+<Summarize the key design tokens — colors, typography, spacing, component patterns, tone.
+Reference the actual file path as the authority. Generators will read it directly and do
+NOT need the frontend-design skill.>
 
-- **Source**: DESIGN.md (awesome-design-md)
-- **Color palette**: <extracted from DESIGN.md with hex values>
-- **Typography**: <extracted from DESIGN.md — font families and weights>
-- **Component patterns**: <key patterns from DESIGN.md — buttons, cards, forms, etc.>
+- **Source**: <actual resolved path> (awesome-design-md)   ← e.g., `docs/DESIGN.md`
+- **Color palette**: <extracted with hex values>
+- **Typography**: <extracted — font families and weights>
+- **Component patterns**: <key patterns — buttons, cards, forms, etc.>
 - **Tone/aesthetic**: <derived from the design system's overall direction>
 
 **If no DESIGN.md exists** (generate from scratch):

--- a/skills/dkh/agents/planner.md
+++ b/skills/dkh/agents/planner.md
@@ -78,17 +78,22 @@ Call `dk_connect` first — all subsequent dkod tools require an active session:
 **Save the `session_id` returned by dk_connect — you will pass it to every subsequent
 dk_* call, including dk_close at the end.**
 
-### Step 1: Discover Existing Specs
+### Step 1: Discover Existing Specs and Design System
 
 Search for existing documentation in the codebase. Check these paths (first match wins):
 
 ```
 PRD.md, prd.md, SPEC.md, spec.md, REQUIREMENTS.md, requirements.md,
-DESIGN.md, design.md, docs/PRD.md, docs/prd.md, docs/SPEC.md, docs/spec.md,
-docs/DESIGN.md, docs/design.md, docs/REQUIREMENTS.md, docs/requirements.md
+docs/PRD.md, docs/prd.md, docs/SPEC.md, docs/spec.md,
+docs/REQUIREMENTS.md, docs/requirements.md
 ```
 
-Use `dk_file_list` to check which files exist, then `dk_file_read` to read the first match.
+**Also check for DESIGN.md** (design system from awesome-design-md):
+```
+DESIGN.md, design.md, docs/DESIGN.md, docs/design.md
+```
+
+Use `dk_file_list` to check which files exist, then `dk_file_read` to read matches.
 
 **If a spec file is found:**
 - Read it (cap at 100KB — if larger, read the first 100KB and note the truncation)
@@ -99,6 +104,19 @@ Use `dk_file_list` to check which files exist, then `dk_file_read` to read the f
 **If no spec file is found:**
 - Generate the full specification from scratch (current behavior)
 - This is the common case for greenfield projects
+
+**If a DESIGN.md file is found (or `HAS_DESIGN_MD = true` from orchestrator):**
+- Read it — this is an awesome-design-md design system document
+- It becomes the **authoritative design reference** for the project
+- Use it to populate the Design Direction section (see Step 3) instead of inventing one
+- Extract: color palette, typography, spacing, component styles, tone/aesthetic
+- Note in the spec: "Design system sourced from DESIGN.md (awesome-design-md)"
+- Generators will follow DESIGN.md directly — no frontend-design skill needed
+
+**If no DESIGN.md exists:**
+- Generate the Design Direction section from scratch (current behavior)
+- Add this note to the plan output:
+  `💡 dkod recommends using a DESIGN.md file for higher-quality frontend design. Browse options at https://github.com/VoltAgent/awesome-design-md`
 
 ### Step 2: Understand the Codebase
 
@@ -162,6 +180,19 @@ Produce a specification that covers:
 - **Build**: <bundler, package manager>
 
 ## Design Direction — MANDATORY for any project with UI
+
+**If DESIGN.md exists** (from awesome-design-md):
+<Summarize the key design tokens from DESIGN.md — colors, typography, spacing, component
+patterns, tone. Reference it as the authority: "See DESIGN.md for complete design system."
+Generators will read DESIGN.md directly and do NOT need the frontend-design skill.>
+
+- **Source**: DESIGN.md (awesome-design-md)
+- **Color palette**: <extracted from DESIGN.md with hex values>
+- **Typography**: <extracted from DESIGN.md — font families and weights>
+- **Component patterns**: <key patterns from DESIGN.md — buttons, cards, forms, etc.>
+- **Tone/aesthetic**: <derived from the design system's overall direction>
+
+**If no DESIGN.md exists** (generate from scratch):
 <This section is required. The frontend-design skill will be invoked by every
 generator that builds UI components. You must define the creative direction here
 so all generators produce a cohesive visual result.>
@@ -449,7 +480,8 @@ if any check fails — save a round trip by catching it yourself:
   have exactly one owner
 - [ ] Every work unit has 5+ testable acceptance criteria
 - [ ] Overall acceptance criteria exist (app starts, no console errors, responsive, etc.)
-- [ ] **For UI projects**: Design Direction section exists with specific tone (not "modern
+- [ ] **For UI projects**: Design Direction section exists — either sourced from DESIGN.md
+  (with extracted tokens) or generated from scratch with specific tone (not "modern
   and clean"), hex color values, and named font choices (not Arial/Inter/Roboto)
 - [ ] **No two units own the same SYMBOL** (same file is fine — dkod AST-merges different
   symbols in the same file automatically). Check OWNS lists for duplicate symbol names.


### PR DESCRIPTION
## Summary

- **Planner**: Checks for `DESIGN.md` (from [awesome-design-md](https://github.com/VoltAgent/awesome-design-md)) during spec discovery. If found, uses it as the authoritative design system — extracts color tokens, typography, spacing, and component patterns directly into the Design Direction section. Falls back to generating Design Direction from scratch with a recommendation note.

- **Generator**: When building UI work units, reads `DESIGN.md` directly if available (no skill invocation needed). Falls back to `Skill(skill: "frontend-design")` with a recommendation to use awesome-design-md.

- **Evaluator**: Prefers Playwright CLI (`npx playwright screenshot`, inline Playwright scripts) over chrome-devtools MCP for all browser testing — navigation, screenshots, console checks, interactive element audits, responsive testing. Falls back to chrome-devtools MCP with a recommendation to install Playwright.

- **Orchestrator**: Runs tool detection during PRE-FLIGHT (`HAS_PLAYWRIGHT`, `HAS_DESIGN_MD` flags). Passes flags to all agent dispatches. Smoke test uses Playwright when available.

- **SKILL.md**: Updated prerequisites to document both preferred and fallback tools with detection flow.

### Graceful fallback pattern

When the preferred tool is **not installed**, the harness:
1. Uses the existing fallback tool (chrome-devtools / frontend-design skill)
2. Outputs a recommendation: `"💡 dkod recommends using..."` with install instructions
3. Continues normally — no blocking, no errors

## Test plan

- [ ] Run `/dkh` on a project **with** `DESIGN.md` — verify planner references it, generators read it directly (no `frontend-design` skill invocation)
- [ ] Run `/dkh` on a project **without** `DESIGN.md` — verify recommendation message appears, `frontend-design` skill is invoked as fallback
- [ ] Run `/dkh` on a machine **with** Playwright installed — verify smoke test and evaluators use Playwright CLI commands
- [ ] Run `/dkh` on a machine **without** Playwright — verify chrome-devtools MCP is used as fallback with recommendation message
- [ ] Verify PRE-FLIGHT outputs detection results for both tools
- [ ] Verify `HAS_PLAYWRIGHT` is passed in evaluator dispatch prompts
- [ ] Verify `HAS_DESIGN_MD` is passed in planner and generator dispatch prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)