### PR TITLE
fix: add wait:true to all blocking dk_watch calls

### DIFF
--- a/skills/dkh/agents/generator.md
+++ b/skills/dkh/agents/generator.md
@@ -97,9 +97,9 @@ response MUST be checked for two conditions:
 1. **SYMBOL_LOCKED** — Another generator holds the lock on a symbol you're trying to write.
    Your write DID NOT happen. You must wait and retry:
    ```
-   dk_watch(filter: "symbol.lock.released")   ← blocks until their lock releases (they merged)
-   dk_file_read(path)                          ← read the file with their merged code
-   dk_file_write(path, adapted_content)        ← write your symbols alongside theirs
+   dk_watch(filter: "symbol.lock.released", wait: true)   ← blocks until lock releases (they merged)
+   dk_file_read(path)                                      ← read the file with their merged code
+   dk_file_write(path, adapted_content)                    ← write your symbols alongside theirs
    ```
 
 2. **conflict_warnings** (legacy) — Informational warning that another generator is active
@@ -136,9 +136,9 @@ for each file in your work unit:
   if response.status == "locked":
     # SYMBOL_LOCKED — another generator holds this symbol
     # Wait for their lock to release (they will merge), then retry
-    dk_watch(filter: "symbol.lock.released")   # blocks until lock releases
-    dk_file_read(path)                          # read their merged code
-    response = dk_file_write(path, adapted_content)  # write alongside theirs
+    dk_watch(filter: "symbol.lock.released", wait: true)   # blocks until lock releases
+    dk_file_read(path)                                      # read their merged code
+    response = dk_file_write(path, adapted_content)         # write alongside theirs
     # If still locked after 3 retries → report as blocked_timeout
 
   if response contains conflict_warnings:
@@ -245,7 +245,7 @@ LOOP while round ≤ 10:
     continue
 
   # ═══ LOCAL IS CLEAN (≥ 4/5) — CHECK DEEP REVIEW ═══
-  dk_watch(filter: "changeset.review.completed")
+  dk_watch(filter: "changeset.review.completed", wait: true)
   dk_review(changeset_id) → get deep findings + score
 
   if deep_score >= 4 AND no severity:"error" findings:

--- a/skills/dkh/references/dkod-patterns.md
+++ b/skills/dkh/references/dkod-patterns.md
@@ -63,9 +63,9 @@ dk_file_write(path: "src/api/tasks.ts", content: "<full file content>")
 
 **If `status: "locked"` is returned:**
 ```
-dk_watch(filter: "symbol.lock.released")   # blocks until their lock releases
-dk_file_read(path)                          # read their merged code
-dk_file_write(path, adapted_content)        # write alongside their code
+dk_watch(filter: "symbol.lock.released", wait: true)   # blocks until lock releases
+dk_file_read(path)                                      # read their merged code
+dk_file_write(path, adapted_content)                    # write alongside their code
 ```
 
 **Lock lifecycle:** Acquired on `dk_file_write`, held through submit/review/merge,
@@ -332,7 +332,7 @@ LOOP while round ≤ 3:
     continue           → re-check local on the new submission
 
   # 2. Local is clean — wait for DEEP review
-  dk_watch(filter: "changeset.review.completed")  — blocks, zero LLM cost
+  dk_watch(filter: "changeset.review.completed", wait: true)  — blocks, zero LLM cost
   dk_review(changeset_id) → deep findings + score
 
   # 3. Check deep review


### PR DESCRIPTION
## Summary

All `dk_watch` calls intended to block now include `wait: true`:
- Symbol lock release waits (`filter: "symbol.lock.released"`)
- Deep review completion waits (`filter: "changeset.review.completed"`)

Without `wait: true`, `dk_watch` returns immediately with "No new watch events" instead of blocking — agents would poll-loop burning tokens.

Matches engine PR dkod-io/dkod-engine#60 which added the blocking mode.

## Test plan

- [ ] Generator blocks on symbol lock release (not poll-loop)
- [ ] Generator blocks on deep review completion (not poll-loop)