### PR TITLE
fix: generators must pass session_id on every dk_* call

### DIFF
--- a/skills/dkh/agents/generator.md
+++ b/skills/dkh/agents/generator.md
@@ -54,7 +54,7 @@ Never call `dk_connect` again — retry `dk_file_write` or `dk_submit` instead.
 
 **Save the `session_id` from the response.** You MUST pass `session_id` explicitly on
 EVERY subsequent `dk_*` call (`dk_file_read`, `dk_file_write`, `dk_context`, `dk_submit`,
-`dk_watch`, `dk_review`, `dk_verify`, `dk_approve`, `dk_merge`, `dk_close`). Multiple
+`dk_watch`, `dk_review`, `dk_verify`, `dk_approve`, `dk_merge`, `dk_resolve`, `dk_close`). Multiple
 generators run in parallel sharing the same MCP process — without an explicit `session_id`,
 the MCP bridge cannot determine which session a call belongs to and will return
 `MCP error -32602: Multiple sessions active`.

--- a/skills/dkh/agents/generator.md
+++ b/skills/dkh/agents/generator.md
@@ -52,6 +52,13 @@ satisfies every acceptance criterion. Submit your changeset when done.
 Call `dk_connect` once with your assigned `agent_name`, `intent`, and `codebase`.
 Never call `dk_connect` again — retry `dk_file_write` or `dk_submit` instead.
 
+**Save the `session_id` from the response.** You MUST pass `session_id` explicitly on
+EVERY subsequent `dk_*` call (`dk_file_read`, `dk_file_write`, `dk_context`, `dk_submit`,
+`dk_watch`, `dk_review`, `dk_verify`, `dk_approve`, `dk_merge`, `dk_close`). Multiple
+generators run in parallel sharing the same MCP process — without an explicit `session_id`,
+the MCP bridge cannot determine which session a call belongs to and will return
+`MCP error -32602: Multiple sessions active`.
+
 ### Step 2: Understand Context
 
 The `dk_connect` response tells you whether the repo is greenfield (0 files) or has


### PR DESCRIPTION
## Summary

Generators running as parallel sub-agents share one MCP instance. Without explicit `session_id` on every `dk_*` call, the MCP bridge can't resolve which session to use and returns `MCP error -32602: Multiple sessions active`.

Added mandatory instruction in Step 1 to save and pass `session_id` on every subsequent tool call.

## Test plan

- [ ] Run parallel build with 8+ generators — no MCP -32602 errors