### PR TITLE
fix: rewrite merge conflict handling — re-submit instead of dk_resolve

### DIFF
--- a/skills/dkh/agents/generator.md
+++ b/skills/dkh/agents/generator.md
@@ -319,11 +319,10 @@ while merge_attempts < MAX_MERGE_ATTEMPTS:
       # Fix verify issues, re-submit, re-verify until clean
       # (same fix loop as Step 5b — don't skip verification)
       break  # report as conflict_unresolved if can't pass verify
-    # 5. Run at least one local review check before approving
-    #    (adapted code may introduce regressions or style violations)
+    # 5. Run at least one review check before approving
+    dk_watch(filter: "changeset.review.completed", wait: true)
     dk_review(changeset_id)
-    if local_score < 4 OR has severity:"error":
-      # Fix review findings, re-submit, re-verify
+    if deep_score < 4 OR has severity:"error":
       break  # report as conflict_unresolved if can't pass review
     dk_approve(changeset_id)
     continue   # retry dk_merge with the new submission

--- a/skills/dkh/agents/generator.md
+++ b/skills/dkh/agents/generator.md
@@ -313,8 +313,18 @@ while merge_attempts < MAX_MERGE_ATTEMPTS:
       dk_file_write(path, adapted_content)
     # 3. Re-submit with the updated code
     dk_submit(intent)
-    # 4. Re-verify and re-approve before retrying merge
-    dk_verify(changeset_id)
+    # 4. Re-verify — if verify fails, fix and re-submit (same as Step 5b)
+    verify_result = dk_verify(changeset_id)
+    if verify_result has failures:
+      # Fix verify issues, re-submit, re-verify until clean
+      # (same fix loop as Step 5b — don't skip verification)
+      break  # report as conflict_unresolved if can't pass verify
+    # 5. Run at least one local review check before approving
+    #    (adapted code may introduce regressions or style violations)
+    dk_review(changeset_id)
+    if local_score < 4 OR has severity:"error":
+      # Fix review findings, re-submit, re-verify
+      break  # report as conflict_unresolved if can't pass review
     dk_approve(changeset_id)
     continue   # retry dk_merge with the new submission
 

--- a/skills/dkh/agents/generator.md
+++ b/skills/dkh/agents/generator.md
@@ -283,21 +283,55 @@ After review gates pass (or max-rounds fallback allows):
 
 ```
 dk_approve(changeset_id)
-result = dk_merge(changeset_id, message: "<unit title>")
 
-if result is MergeSuccess:
-  OUTPUT: "Merged — commit: {commit_hash}"
-  # Lock released automatically. Other blocked generators will wake up.
+merge_attempts = 0
+MAX_MERGE_ATTEMPTS = 3
 
-if result is MergeConflict:
-  # Another generator's merge created a conflict with your symbols
-  dk_resolve(resolution: "proceed")   # accept your changes
-  result = dk_merge(changeset_id)     # retry
-  # If still failing after 3 retries → report as conflict_unresolved
+while merge_attempts < MAX_MERGE_ATTEMPTS:
+  merge_attempts += 1
+  result = dk_merge(changeset_id, message: "<unit title>")
 
-if result is OverwriteWarning:
-  dk_merge(changeset_id, force: true)  # your version is authoritative
+  if result is MergeSuccess:
+    OUTPUT: "Merged — commit: {commit_hash}"
+    break   # Lock released automatically. Other blocked generators wake up.
+
+  if result is OverwriteWarning:
+    result = dk_merge(changeset_id, force: true)
+    if result is MergeSuccess:
+      OUTPUT: "Merged (force) — commit: {commit_hash}"
+      break
+
+  if result is MergeConflict:
+    # Another generator merged while you were in review — HEAD moved.
+    # Do NOT call dk_resolve blindly. Instead: re-read, re-write, re-submit.
+    OUTPUT: "Merge conflict (attempt {merge_attempts}/{MAX_MERGE_ATTEMPTS}) — re-reading and re-submitting"
+    # 1. Read the conflicting files to see what the other generator wrote
+    for each conflicting file in result.conflicts:
+      dk_file_read(file_path)
+    # 2. Re-write your files to work alongside their merged code
+    for each of your files:
+      dk_file_write(path, adapted_content)
+    # 3. Re-submit with the updated code
+    dk_submit(intent)
+    # 4. Re-verify and re-approve before retrying merge
+    dk_verify(changeset_id)
+    dk_approve(changeset_id)
+    continue   # retry dk_merge with the new submission
+
+  # Any other error (FailedPrecondition, etc.) — do NOT call dk_resolve.
+  # dk_resolve is ONLY for changesets the platform has explicitly flagged as
+  # conflicted. If you get FailedPrecondition, the changeset is NOT in a
+  # conflicted state — calling dk_resolve will fail repeatedly.
+  OUTPUT: "Merge error (attempt {merge_attempts}): {error}"
+  if merge_attempts >= MAX_MERGE_ATTEMPTS:
+    break
+
+# If all merge attempts exhausted → report as conflict_unresolved
 ```
+
+**NEVER call `dk_resolve` unless the platform explicitly returns a conflict state
+that requires resolution.** Most merge failures are rebase conflicts from HEAD moving —
+the fix is re-read → re-write → re-submit → re-approve → retry merge, not dk_resolve.
 
 ### Step 6: Report
 


### PR DESCRIPTION
## Summary

Generators were calling `dk_resolve(resolution: "proceed")` blindly after any merge failure, hitting `FailedPrecondition` when the changeset wasn't in a conflicted state. This caused an infinite retry loop burning 30K+ tokens per generator.

**Before:** `MergeConflict → dk_resolve("proceed") → FailedPrecondition → retry → loop forever`

**After:** `MergeConflict → dk_file_read conflicting files → dk_file_write adapted code → dk_submit → dk_verify → dk_approve → retry dk_merge (max 3 attempts)`

`dk_resolve` is now explicitly documented as off-limits for general merge failures — only for platform-flagged conflict states.

## Test plan

- [ ] Run parallel build — generators handle merge conflicts by re-reading and re-submitting
- [ ] No `dk_resolve: FailedPrecondition` errors in agent status
- [ ] Generators report `conflict_unresolved` after 3 failed attempts instead of looping