### PR TITLE
fix: ask user before installing Playwright and awesome-design-md

### DIFF
--- a/skills/dkh/SKILL.md
+++ b/skills/dkh/SKILL.md
@@ -114,7 +114,7 @@ Before starting, verify these are available:
      `evaluate_script`, `list_console_messages`, `lighthouse_audit`. Used only if Playwright
      is not installed.
    - If NEITHER is available, evaluation falls to `dk_verify` + code review (no live UI testing).
-     Output: `"⚠️ dkod recommends using Playwright for browser testing: npm i -D @playwright/test && npx playwright install chromium"`
+     Ask: `"Playwright not found. Install it for better browser testing? (yes/no)"` — install only if user confirms.
 
 3. **Design system (pick one — DESIGN.md preferred):**
    - **DESIGN.md** (preferred): A design system file in the project root, sourced from
@@ -125,7 +125,7 @@ Before starting, verify these are available:
    - **frontend-design skill** (fallback): If no DESIGN.md exists, generators invoke
      `Skill(skill: "frontend-design")` before implementing UI components. The planner still
      generates a Design Direction section in the spec. The evaluator still scores design quality.
-     Output: `"💡 dkod recommends using a DESIGN.md file for higher-quality frontend design. Browse options at https://github.com/VoltAgent/awesome-design-md"`
+     Ask: `"No DESIGN.md found. Browse design systems at https://github.com/VoltAgent/awesome-design-md — want to install one? (yes/no)"` — install only if user confirms.
    - If NEITHER is available, generators follow the planner's Design Direction section manually.
 
 **Detection flow (run once during PRE-FLIGHT):**

--- a/skills/dkh/SKILL.md
+++ b/skills/dkh/SKILL.md
@@ -113,8 +113,8 @@ Before starting, verify these are available:
    - **chrome-devtools MCP** (fallback): `navigate_page`, `take_screenshot`, `click`,
      `evaluate_script`, `list_console_messages`, `lighthouse_audit`. Used only if Playwright
      is not installed.
-   - If NEITHER is available, evaluation falls to `dk_verify` + code review (no live UI testing).
-     Ask: `"Playwright not found. Install it for better browser testing? (yes/no)"` — install only if user confirms.
+   - If Playwright is not found, ask the user during preflight (60s timeout, continue without if no response).
+   - If NEITHER Playwright nor chrome-devtools is available, evaluation falls to `dk_verify` + code review (no live UI testing).
 
 3. **Design system (pick one — DESIGN.md preferred):**
    - **DESIGN.md** (preferred): A design system file in the project root, sourced from
@@ -125,7 +125,7 @@ Before starting, verify these are available:
    - **frontend-design skill** (fallback): If no DESIGN.md exists, generators invoke
      `Skill(skill: "frontend-design")` before implementing UI components. The planner still
      generates a Design Direction section in the spec. The evaluator still scores design quality.
-     Ask: `"No DESIGN.md found. Browse design systems at https://github.com/VoltAgent/awesome-design-md — want to install one? (yes/no)"` — install only if user confirms.
+     If not found, ask the user during preflight (60s timeout, continue without if no response).
    - If NEITHER is available, generators follow the planner's Design Direction section manually.
 
 **Detection flow (run once during PRE-FLIGHT):**

--- a/skills/dkh/agents/orchestrator.md
+++ b/skills/dkh/agents/orchestrator.md
@@ -154,13 +154,15 @@ HAS_DESIGN_MD=false
 **If `HAS_PLAYWRIGHT = false`:**
 Ask the user: `"Playwright not found. Install it for better browser testing? (yes/no) — dkod harness is autonomous, waiting 60s then continuing without it..."`
 Show a countdown: `"⏳ 60s..."`, `"⏳ 30s..."`, `"⏳ 10s..."`.
-If user responds yes/ok/go within 60s → run `npm i -D @playwright/test && npx playwright install chromium`, set `HAS_PLAYWRIGHT=true`.
+If user responds yes/ok/go within 60s → run `npm i -D @playwright/test && npx playwright install chromium`.
+Re-verify: `timeout 10 npx playwright --version 2>/dev/null && HAS_PLAYWRIGHT=true`. Only trust the flag if the install actually worked.
 If no or no response within 60s → proceed with chrome-devtools MCP fallback.
 
 **If `HAS_DESIGN_MD = false` and the project has UI:**
 Ask the user: `"No DESIGN.md found. Browse design systems at https://github.com/VoltAgent/awesome-design-md — want to install one? (yes/no) — continuing in 60s..."`
 Show a countdown: `"⏳ 60s..."`, `"⏳ 30s..."`, `"⏳ 10s..."`.
-If user responds yes/ok/go within 60s → run `npx awesome-design-md`, set `HAS_DESIGN_MD=true` if file was created.
+If user responds yes/ok/go within 60s → run `npx awesome-design-md`.
+Re-verify: check if DESIGN.md/design.md exists, only set `HAS_DESIGN_MD=true` if file was created.
 If no or no response within 60s → proceed with frontend-design skill fallback.
 
 **Pass these flags to every agent dispatch:**

--- a/skills/dkh/agents/orchestrator.md
+++ b/skills/dkh/agents/orchestrator.md
@@ -152,14 +152,16 @@ HAS_DESIGN_MD=false
 ```
 
 **If `HAS_PLAYWRIGHT = false`:**
-Ask the user: `"Playwright not found. Install it for better browser testing? (yes/no)"`
-Wait for response. If yes/ok/go → run `npm i -D @playwright/test && npx playwright install chromium`, set `HAS_PLAYWRIGHT=true`.
-If no → proceed with chrome-devtools MCP fallback.
+Ask the user: `"Playwright not found. Install it for better browser testing? (yes/no) — dkod harness is autonomous, waiting 60s then continuing without it..."`
+Show a countdown: `"⏳ 60s..."`, `"⏳ 30s..."`, `"⏳ 10s..."`.
+If user responds yes/ok/go within 60s → run `npm i -D @playwright/test && npx playwright install chromium`, set `HAS_PLAYWRIGHT=true`.
+If no or no response within 60s → proceed with chrome-devtools MCP fallback.
 
 **If `HAS_DESIGN_MD = false` and the project has UI:**
-Ask the user: `"No DESIGN.md found. Browse design systems at https://github.com/VoltAgent/awesome-design-md — want to install one? (yes/no)"`
-Wait for response. If yes/ok/go → run `npx awesome-design-md`, set `HAS_DESIGN_MD=true` if file was created.
-If no → proceed with frontend-design skill fallback.
+Ask the user: `"No DESIGN.md found. Browse design systems at https://github.com/VoltAgent/awesome-design-md — want to install one? (yes/no) — continuing in 60s..."`
+Show a countdown: `"⏳ 60s..."`, `"⏳ 30s..."`, `"⏳ 10s..."`.
+If user responds yes/ok/go within 60s → run `npx awesome-design-md`, set `HAS_DESIGN_MD=true` if file was created.
+If no or no response within 60s → proceed with frontend-design skill fallback.
 
 **Pass these flags to every agent dispatch:**
 - Planner: include `HAS_DESIGN_MD` in the prompt

--- a/skills/dkh/agents/orchestrator.md
+++ b/skills/dkh/agents/orchestrator.md
@@ -152,10 +152,14 @@ HAS_DESIGN_MD=false
 ```
 
 **If `HAS_PLAYWRIGHT = false`:**
-Output: `"💡 dkod recommends using Playwright for more reliable browser testing: npm i -D @playwright/test && npx playwright install chromium"`
+Ask the user: `"Playwright not found. Install it for better browser testing? (yes/no)"`
+Wait for response. If yes/ok/go → run `npm i -D @playwright/test && npx playwright install chromium`, set `HAS_PLAYWRIGHT=true`.
+If no → proceed with chrome-devtools MCP fallback.
 
 **If `HAS_DESIGN_MD = false` and the project has UI:**
-Output: `"💡 dkod recommends using a DESIGN.md file for higher-quality frontend design. Browse options at https://github.com/VoltAgent/awesome-design-md"`
+Ask the user: `"No DESIGN.md found. Browse design systems at https://github.com/VoltAgent/awesome-design-md — want to install one? (yes/no)"`
+Wait for response. If yes/ok/go → run `npx awesome-design-md`, set `HAS_DESIGN_MD=true` if file was created.
+If no → proceed with frontend-design skill fallback.
 
 **Pass these flags to every agent dispatch:**
 - Planner: include `HAS_DESIGN_MD` in the prompt


### PR DESCRIPTION
## Summary

Preflight now asks the user for confirmation before installing Playwright or awesome-design-md. Each tool is asked separately — user can accept one and decline the other.

- **Playwright**: `"Playwright not found. Install it for better browser testing? (yes/no)"`
- **DESIGN.md**: `"No DESIGN.md found. Browse design systems at ... — want to install one? (yes/no)"`

Only installs on explicit yes/ok/go. Falls back gracefully on no.

## Test plan

- [ ] Run harness without Playwright — user is asked, can say no
- [ ] Run harness without DESIGN.md — user is asked, can say no
- [ ] Say yes to Playwright — installed correctly
- [ ] Say yes to DESIGN.md — installed correctly