### PR TITLE
fix: Playwright detection uses playwright-cli + remove AskUserQuestion

### DIFF
--- a/skills/dkh/SKILL.md
+++ b/skills/dkh/SKILL.md
@@ -104,16 +104,14 @@ Before starting, verify these are available:
    `dk_review`, `dk_approve`, `dk_merge`, `dk_push`, `dk_status`, `dk_watch`
 
 2. **Browser testing (pick one — Playwright preferred):**
-   - **Playwright** (preferred): Check with `timeout 10 npx playwright --version`. Uses
-     `@playwright/test` as a library via inline Node.js scripts (`node -e "..."`) for
-     navigation, screenshots, clicks, form fills, console checks, and JS evaluation.
-     Runs headless by default, needs no MCP server, produces deterministic results.
-     CLI subcommands (`npx playwright test`, `npx playwright codegen`) available for
-     structured test runs.
+   - **playwright-cli** (preferred): Check with `playwright-cli --version`. Standalone
+     CLI for skills-less browser automation — screenshots, script execution, PDF generation.
+     No Node.js scripts needed, no MCP server, runs headless by default.
+     See: https://github.com/microsoft/playwright-cli
    - **chrome-devtools MCP** (fallback): `navigate_page`, `take_screenshot`, `click`,
      `evaluate_script`, `list_console_messages`, `lighthouse_audit`. Used only if Playwright
      is not installed.
-   - If Playwright is not found, ask the user during preflight (60s timeout, continue without if no response).
+   - If not found, output install instructions and proceed with fallback. Do NOT ask the user or install.
    - If NEITHER Playwright nor chrome-devtools is available, evaluation falls to `dk_verify` + code review (no live UI testing).
 
 3. **Design system (pick one — DESIGN.md preferred):**
@@ -125,14 +123,14 @@ Before starting, verify these are available:
    - **frontend-design skill** (fallback): If no DESIGN.md exists, generators invoke
      `Skill(skill: "frontend-design")` before implementing UI components. The planner still
      generates a Design Direction section in the spec. The evaluator still scores design quality.
-     If not found, ask the user during preflight (60s timeout, continue without if no response).
+     If not found, output install instructions and proceed with fallback. Do NOT ask the user or install.
    - If NEITHER is available, generators follow the planner's Design Direction section manually.
 
 **Detection flow (run once during PRE-FLIGHT):**
 ```bash
-# 1. Detect Playwright (@playwright/test)
+# 1. Detect playwright-cli (standalone CLI, skills-less operation)
 HAS_PLAYWRIGHT=false
-timeout 10 npx playwright --version 2>/dev/null && HAS_PLAYWRIGHT=true
+playwright-cli --version 2>/dev/null && HAS_PLAYWRIGHT=true
 
 # 2. Detect DESIGN.md (check all paths the planner searches)
 HAS_DESIGN_MD=false

--- a/skills/dkh/agents/evaluator.md
+++ b/skills/dkh/agents/evaluator.md
@@ -20,17 +20,16 @@ the criteria you receive (per-unit or integration).
 The orchestrator passes `HAS_PLAYWRIGHT` in your dispatch prompt. This determines which
 browser testing approach you use:
 
-**If `HAS_PLAYWRIGHT = true` → Use Playwright (preferred):**
-Playwright runs headless Chrome via inline Node.js scripts (`node -e "..."`). Use
-`require('playwright')` to launch browsers, navigate, screenshot, click, fill, and
-evaluate JS. More reliable and deterministic than MCP — no browser extension needed.
-All browser interactions in Steps 5a-5c below show both Playwright and chrome-devtools
-equivalents — use the Playwright versions.
+**If `HAS_PLAYWRIGHT = true` → Use playwright-cli (preferred):**
+Use `playwright-cli` CLI commands for browser automation — screenshots, script execution.
+More reliable and deterministic than MCP — no browser extension needed.
+All browser interactions in Steps 5a-5c below show both playwright-cli and chrome-devtools
+equivalents — use the playwright-cli versions.
 
 **If `HAS_PLAYWRIGHT = false` → Use chrome-devtools MCP (fallback):**
 Use the chrome-devtools MCP tools as documented in the fallback sections below.
 Output once at the start of your report:
-`"💡 dkod recommends using Playwright for more reliable browser testing: npm i -D @playwright/test && npx playwright install chromium"`
+`"💡 To enable playwright-cli: npm i -g @playwright/cli — see https://github.com/microsoft/playwright-cli"`
 
 **Time budget:** The orchestrator injects your time budget in the dispatch prompt (typically
 30 minutes per unit in your batch — e.g., 60 min for a 2-unit batch, 90 min for 3-unit).
@@ -163,30 +162,17 @@ renders but does nothing on click is broken — even if no criterion mentions it
 
 #### If `HAS_PLAYWRIGHT = true`
 
-1. **Discover elements** via Playwright script:
+1. **Discover elements** — write a script that finds all interactive elements, then:
    ```bash
-   timeout 30 node -e "
-     const { chromium } = require('playwright');
-     (async () => {
-       const browser = await chromium.launch();
-       const page = await browser.newPage();
-       await page.goto('<URL>', { waitUntil: 'networkidle' });
-       const elements = await page.evaluate(() => {
-         return [...document.querySelectorAll('button, [role=\"button\"], a[href], [onclick], [tabindex=\"0\"]')]
-           .filter(el => { const s = getComputedStyle(el); return s.display !== 'none' && s.visibility !== 'hidden' && el.offsetParent !== null; })
-           .filter(el => !el.disabled && el.getAttribute('aria-disabled') !== 'true')
-           .filter(el => !el.href || el.href.startsWith(location.origin) || el.href.startsWith('#'))
-           .map(el => ({ tag: el.tagName, text: (el.textContent||'').trim().slice(0,60), id: el.id||null }));
-       });
-       console.log(JSON.stringify(elements));
-       await browser.close();
-     })();
-   "
+   playwright-cli execute <URL> --script discover-elements.js
    ```
 
-2. **Test each element** via Playwright script: screenshot before → click → wait 5s →
-   screenshot after. Compare URL/title/content before and after.
-   Identical before/after → element is dead → **3/10 max**.
+2. **Test each element** — screenshot before → click → wait → screenshot after:
+   ```bash
+   playwright-cli screenshot <URL> before.png
+   playwright-cli execute <URL> --script click-element.js --screenshot after.png
+   ```
+   Compare before/after. Identical → element is dead → **3/10 max**.
 
 3. **Judgment calls:** Always test buttons with text, nav links, form submits. Skip decorative
    elements, disabled buttons, data-entry inputs. Sample 2-3 from identical lists.

--- a/skills/dkh/agents/evaluator.md
+++ b/skills/dkh/agents/evaluator.md
@@ -81,99 +81,33 @@ Otherwise, start the dev server yourself and track `I_STARTED_SERVER = true`.
 
 **After EVERY navigation, verify loading completes.**
 
-#### If `HAS_PLAYWRIGHT = true` — Playwright
+#### If `HAS_PLAYWRIGHT = true` — playwright-cli
 
-Use inline Node.js scripts via Bash with `timeout 30` prefix. All scripts use
-`require('playwright')` to launch a headless browser.
+Use `playwright-cli` for skills-less browser automation. No Node.js scripts needed.
 
 1. **Navigate + screenshot:**
    ```bash
-   timeout 30 node -e "
-     const { chromium } = require('playwright');
-     (async () => {
-       const browser = await chromium.launch();
-       const page = await browser.newPage();
-       await page.goto('<URL>', { waitUntil: 'networkidle' });
-       await page.screenshot({ path: 'screenshot-initial.png' });
-       await browser.close();
-     })();
-   "
+   playwright-cli screenshot <URL> screenshot-initial.png
    ```
 
-2. **Detect loading indicators:**
+2. **Execute script + screenshot** (for interactions, assertions):
    ```bash
-   timeout 30 node -e "
-     const { chromium } = require('playwright');
-     (async () => {
-       const browser = await chromium.launch();
-       const page = await browser.newPage();
-       await page.goto('<URL>', { waitUntil: 'networkidle' });
-       const result = await page.evaluate(() => {
-         const loadingEls = [...document.querySelectorAll('[aria-busy=\"true\"], [class*=\"spinner\"], [class*=\"loading\"], [class*=\"skeleton\"]')]
-           .filter(el => getComputedStyle(el).display !== 'none');
-         const loadingText = [...document.querySelectorAll('*')].filter(el =>
-           el.children.length === 0 && /^(loading|please wait)/i.test(el.textContent.trim()));
-         return { isLoading: loadingEls.length + loadingText.length > 0, count: loadingEls.length + loadingText.length };
-       });
-       console.log(JSON.stringify(result));
-       await browser.close();
-     })();
-   "
+   playwright-cli execute <URL> --script check.js --screenshot after.png
    ```
-   If loading, wait 10s and recheck. Still loading → **FAIL (3/10 max)**.
+   Write the script to a temp file first, then execute it. Scripts have access to
+   `page` (Playwright Page object) in the execution context.
 
-3. **Final screenshot** (must show real content):
+3. **Check console errors:**
    ```bash
-   timeout 30 node -e "
-     const { chromium } = require('playwright');
-     (async () => {
-       const browser = await chromium.launch();
-       const page = await browser.newPage();
-       await page.goto('<URL>', { waitUntil: 'networkidle' });
-       await page.screenshot({ path: 'screenshot-final.png' });
-       await browser.close();
-     })();
-   "
+   playwright-cli execute <URL> --script console-check.js
    ```
+   Script: `page.on('console', msg => { if (msg.type() === 'error') console.log(msg.text()); });`
 
-4. **Check console errors:**
-   ```bash
-   timeout 30 node -e "
-     const { chromium } = require('playwright');
-     (async () => {
-       const browser = await chromium.launch();
-       const page = await browser.newPage();
-       const errors = [];
-       page.on('console', msg => { if (msg.type() === 'error') errors.push(msg.text()); });
-       await page.goto('<URL>', { waitUntil: 'networkidle' });
-       await browser.close();
-       console.log(JSON.stringify({ errors, count: errors.length }));
-     })();
-   "
-   ```
-
-**Playwright testing patterns:**
-- **UI criteria:** screenshot → script (navigate, click, fill, assert) → screenshot
-- **API criteria:** `curl` via Bash or `page.evaluate(() => fetch(...))`
-- **Error handling:** submit empty forms, navigate to invalid routes, send bad API requests
-- **Responsive:** use `browser.newContext({ viewport: { width: 375, height: 812 } })` for
-  mobile, `{ width: 1440, height: 900 }` for desktop — screenshot each
-- **Interactions:**
-  ```bash
-  timeout 30 node -e "
-    const { chromium } = require('playwright');
-    (async () => {
-      const browser = await chromium.launch();
-      const page = await browser.newPage();
-      await page.goto('<URL>', { waitUntil: 'networkidle' });
-      await page.click('button:has-text(\"Submit\")');
-      await page.waitForTimeout(2000);
-      await page.screenshot({ path: 'after-click.png' });
-      console.log(JSON.stringify({ url: page.url(), title: await page.title() }));
-      await browser.close();
-    })();
-  "
-  ```
+**playwright-cli testing patterns:**
+- **UI criteria:** `playwright-cli screenshot <URL> <output.png>` → Read the image
+- **API criteria:** `curl` via Bash
+- **Interactions:** write a script file, then `playwright-cli execute <URL> --script <file>`
+- **Responsive:** `playwright-cli screenshot <URL> <output.png> --width 375 --height 812`
 
 #### If `HAS_PLAYWRIGHT = false` — chrome-devtools MCP (fallback)
 

--- a/skills/dkh/agents/orchestrator.md
+++ b/skills/dkh/agents/orchestrator.md
@@ -153,7 +153,7 @@ HAS_DESIGN_MD=false
 
 **If `HAS_PLAYWRIGHT = false`:**
 Output: `"Playwright CLI: ❌ not found — will use chrome-devtools MCP"`
-Output: `"💡 To enable Playwright: npm i -D @playwright/test && npx playwright install chromium"`
+Output: `"💡 To enable playwright-cli: npm i -g @playwright/cli — see https://github.com/microsoft/playwright-cli"`
 Proceed with chrome-devtools MCP fallback. Do NOT ask the user or install anything.
 
 **If `HAS_DESIGN_MD = false` and the project has UI:**

--- a/skills/dkh/agents/orchestrator.md
+++ b/skills/dkh/agents/orchestrator.md
@@ -134,9 +134,9 @@ Bash: curl -sf -X POST "https://api.dkod.io/api/repos/<owner>/<repo>/changesets/
 Detect preferred tools and store flags for all subsequent agent dispatches:
 
 ```bash
-# 1. Detect Playwright (@playwright/test)
+# 1. Detect playwright-cli (standalone CLI, skills-less operation)
 HAS_PLAYWRIGHT=false
-timeout 10 npx playwright --version 2>/dev/null && HAS_PLAYWRIGHT=true
+playwright-cli --version 2>/dev/null && HAS_PLAYWRIGHT=true
 
 # 2. Detect DESIGN.md (awesome-design-md design system)
 # Check all paths the planner searches: DESIGN.md, design.md, docs/DESIGN.md, docs/design.md
@@ -152,18 +152,14 @@ HAS_DESIGN_MD=false
 ```
 
 **If `HAS_PLAYWRIGHT = false`:**
-Ask the user: `"Playwright not found. Install it for better browser testing? (yes/no) — dkod harness is autonomous, waiting 60s then continuing without it..."`
-Show a countdown: `"⏳ 60s..."`, `"⏳ 30s..."`, `"⏳ 10s..."`.
-If user responds yes/ok/go within 60s → run `npm i -D @playwright/test && npx playwright install chromium`.
-Re-verify: `timeout 10 npx playwright --version 2>/dev/null && HAS_PLAYWRIGHT=true`. Only trust the flag if the install actually worked.
-If no or no response within 60s → proceed with chrome-devtools MCP fallback.
+Output: `"Playwright CLI: ❌ not found — will use chrome-devtools MCP"`
+Output: `"💡 To enable Playwright: npm i -D @playwright/test && npx playwright install chromium"`
+Proceed with chrome-devtools MCP fallback. Do NOT ask the user or install anything.
 
 **If `HAS_DESIGN_MD = false` and the project has UI:**
-Ask the user: `"No DESIGN.md found. Browse design systems at https://github.com/VoltAgent/awesome-design-md — want to install one? (yes/no) — continuing in 60s..."`
-Show a countdown: `"⏳ 60s..."`, `"⏳ 30s..."`, `"⏳ 10s..."`.
-If user responds yes/ok/go within 60s → run `npx awesome-design-md`.
-Re-verify: check if DESIGN.md/design.md exists, only set `HAS_DESIGN_MD=true` if file was created.
-If no or no response within 60s → proceed with frontend-design skill fallback.
+Output: `"DESIGN.md: ❌ not found — will use frontend-design skill"`
+Output: `"💡 For better design: browse https://github.com/VoltAgent/awesome-design-md"`
+Proceed with frontend-design skill fallback. Do NOT ask the user or install anything.
 
 **Pass these flags to every agent dispatch:**
 - Planner: include `HAS_DESIGN_MD` in the prompt
@@ -333,16 +329,7 @@ tokens testing a broken app. Fix the build first.
 
    **If `HAS_PLAYWRIGHT = true`:**
    ```bash
-   timeout 30 node -e "
-     const { chromium } = require('playwright');
-     (async () => {
-       const browser = await chromium.launch();
-       const page = await browser.newPage();
-       await page.goto('<APP_URL>', { waitUntil: 'networkidle' });
-       await page.screenshot({ path: 'smoke-test.png' });
-       await browser.close();
-     })();
-   "
+   playwright-cli screenshot <APP_URL> smoke-test.png
    ```
    Then read `smoke-test.png` to confirm it shows real content.
 
@@ -353,20 +340,9 @@ tokens testing a broken app. Fix the build first.
 5. **Check the console** — check for fatal errors:
 
    **If `HAS_PLAYWRIGHT = true`:**
+   Write a script to check console errors, then:
    ```bash
-   timeout 30 node -e "
-     const { chromium } = require('playwright');
-     (async () => {
-       const browser = await chromium.launch();
-       const page = await browser.newPage();
-       const errors = [];
-       page.on('console', msg => { if (msg.type() === 'error') errors.push(msg.text()); });
-       await page.goto('<APP_URL>', { waitUntil: 'networkidle' });
-       await browser.close();
-       if (errors.length) { console.log('ERRORS:', JSON.stringify(errors)); process.exit(1); }
-       console.log('No fatal console errors');
-     })();
-   "
+   playwright-cli execute <APP_URL> --script console-check.js
    ```
 
    **If `HAS_PLAYWRIGHT = false`:**


### PR DESCRIPTION
## Summary

- Detection uses `playwright-cli --version` instead of `timeout 10 npx playwright --version` (timeout doesn't exist on macOS, npx is the wrong binary)
- Replaced AskUserQuestion install prompts with autonomous detect-report-continue — outputs install instructions but never blocks the build

## Test plan

- [ ] `playwright-cli --version` detected correctly on macOS
- [ ] No AskUserQuestion blocking the preflight
- [ ] Missing tools logged with install instructions, build continues