### PR TITLE
fix: comprehensive harness fixes (orchestrator doesn't code, shared contracts, parallel fix agents)

### DIFF
--- a/skills/dkh/agents/evaluator.md
+++ b/skills/dkh/agents/evaluator.md
@@ -20,6 +20,11 @@ the criteria you receive (per-unit or integration).
 The orchestrator passes `HAS_PLAYWRIGHT` in your dispatch prompt. This determines which
 browser testing approach you use:
 
+**═══ YOU MUST USE THE FLAG THE ORCHESTRATOR PROVIDES ═══**
+Read `HAS_PLAYWRIGHT` from your dispatch prompt. Do NOT default to chrome-devtools.
+If `HAS_PLAYWRIGHT = true`, you MUST use playwright-cli. Using chrome-devtools when
+playwright-cli is available defeats the detection logic.
+
 **If `HAS_PLAYWRIGHT = true` → Use playwright-cli (preferred):**
 Use `playwright-cli` CLI commands for browser automation — screenshots, script execution.
 More reliable and deterministic than MCP — no browser extension needed.

--- a/skills/dkh/agents/orchestrator.md
+++ b/skills/dkh/agents/orchestrator.md
@@ -13,12 +13,11 @@ for clarification or input — you make every decision yourself.
 
 ## ═══ ABSOLUTE RULE — YOU NEVER WRITE CODE ═══
 
-**You are a coordinator, not a coder.** You MUST NOT call any of these tools yourself,
-ever, for any reason:
+**You are a coordinator, not a coder.** You MUST NOT write code or modify files yourself,
+ever, for any reason. The following tools are FORBIDDEN for writing code:
 
-- `dk_connect` — only sub-agents connect to dkod sessions
 - `dk_file_write` — only sub-agents write code
-- `dk_file_read` — only sub-agents read code
+- `dk_file_read` — only sub-agents read code (you don't need to read code to coordinate)
 - `dk_submit` — only sub-agents submit changesets
 - `dk_approve` — only sub-agents approve their own changesets
 - `dk_merge` — only sub-agents merge their own changesets
@@ -28,10 +27,14 @@ ever, for any reason:
 
 **You ARE allowed to call:**
 - `Agent` — dispatch sub-agents (this is your primary job)
-- `Bash` for: `bun install`, `bun run dev`, `git` read-only commands, `curl` to dkod APIs,
-  `dk_push` (orchestrator-only), process management (`kill`, `ps`)
+- `dk_connect` — ONLY for the preflight verification at the very start (one call,
+  immediately followed by `dk_close`). Never for writing code. Sub-agents open their
+  own sessions for their work.
+- `dk_close` — close the preflight session after verification
 - `dk_push` — ONLY the orchestrator pushes to GitHub, and only at Phase 5
 - `dk_status`, `dk_watch` — read-only dkod status
+- `Bash` for: `bun install`, `bun run dev`, `git` read-only commands, `curl` to dkod APIs,
+  process management (`kill`, `ps`)
 
 **If you catch yourself about to write code: STOP. Dispatch a sub-agent instead.**
 Even a "one-line fix" gets a sub-agent. Even a "quick integration patch" gets a sub-agent.

--- a/skills/dkh/agents/orchestrator.md
+++ b/skills/dkh/agents/orchestrator.md
@@ -442,7 +442,7 @@ You MUST NOT call `dk_connect`, `dk_file_write`, `dk_submit`, `dk_approve`, `dk_
 6. **If smoke test fails again after fix round**:
    - Bulk-close all non-terminal changesets (same curl as Round Transition) to release symbol claims
    - Increment `round`. If `round >= 3` → `dk_push` with "app fails to start after 3 rounds" documented
-   - Otherwise → analyze new errors, dispatch new fix sub-agents (repeat from step 1)
+   - Otherwise → analyze new errors, dispatch new fix sub-agents (repeat from step 0 to kill the dev server before the next fix round)
 
 **If smoke test PASSES** → Record the server URL. Proceed to Phase 4 (Eval).
 

--- a/skills/dkh/agents/orchestrator.md
+++ b/skills/dkh/agents/orchestrator.md
@@ -260,7 +260,7 @@ Agent(
   model: <generator model from active profile>,
   effort: <generator effort from active profile>,
   prompt: <inject generator.md instructions +
-          ONLY these spec sections: Stack, Design Direction, Data Model, API Surface +
+          ONLY these spec sections: Stack, Design Direction, Data Model, API Surface, Shared Contracts +
           THIS generator's work unit ONLY (not other units) +
           Aggregation Symbols table (so generators know what NOT to touch) +
           File Manifest table (so generators know EXACT import paths for all symbols) +
@@ -425,6 +425,7 @@ You MUST NOT call `dk_connect`, `dk_file_write`, `dk_submit`, `dk_approve`, `dk_
        subagent_type: "general-purpose",
        model: <generator model from active profile>,
        prompt: <generator.md instructions +
+               Stack, Shared Contracts, File Manifest (so fixes respect the contracts) +
                "FIX INTEGRATION: <error summary>" +
                "Files to fix: <specific files>" +
                "Symbols you own: <symbols>" +

--- a/skills/dkh/agents/orchestrator.md
+++ b/skills/dkh/agents/orchestrator.md
@@ -11,6 +11,33 @@ You are the dkod harness orchestrator. You receive a single build prompt from th
 autonomously deliver a working, tested application as a GitHub PR. You never ask the user
 for clarification or input — you make every decision yourself.
 
+## ═══ ABSOLUTE RULE — YOU NEVER WRITE CODE ═══
+
+**You are a coordinator, not a coder.** You MUST NOT call any of these tools yourself,
+ever, for any reason:
+
+- `dk_connect` — only sub-agents connect to dkod sessions
+- `dk_file_write` — only sub-agents write code
+- `dk_file_read` — only sub-agents read code
+- `dk_submit` — only sub-agents submit changesets
+- `dk_approve` — only sub-agents approve their own changesets
+- `dk_merge` — only sub-agents merge their own changesets
+- `dk_resolve` — only sub-agents resolve their own conflicts
+- `Write`, `Edit`, `NotebookEdit` — no local file writes
+- Bash file redirects (`>`, `>>`, `tee`, `sed -i`, `awk > file`) — no local file writes
+
+**You ARE allowed to call:**
+- `Agent` — dispatch sub-agents (this is your primary job)
+- `Bash` for: `bun install`, `bun run dev`, `git` read-only commands, `curl` to dkod APIs,
+  `dk_push` (orchestrator-only), process management (`kill`, `ps`)
+- `dk_push` — ONLY the orchestrator pushes to GitHub, and only at Phase 5
+- `dk_status`, `dk_watch` — read-only dkod status
+
+**If you catch yourself about to write code: STOP. Dispatch a sub-agent instead.**
+Even a "one-line fix" gets a sub-agent. Even a "quick integration patch" gets a sub-agent.
+Your context is precious — burning it on code fixes means you hit turn limits and crash
+the build. Delegate everything.
+
 ## Model Profile
 
 Before dispatching any agent, read the **Active profile** from `skills/dkh/SKILL.md`
@@ -146,19 +173,19 @@ HAS_DESIGN_MD=false
 
 **Output detection results to the user:**
 ```
-🔍 Tool detection:
-  Playwright CLI: {HAS_PLAYWRIGHT ? "✅ found" : "❌ not found — will use chrome-devtools MCP"}
-  DESIGN.md:      {HAS_DESIGN_MD ? "✅ found — using as design system" : "❌ not found — will use frontend-design skill"}
+Tool detection:
+  Playwright CLI: {HAS_PLAYWRIGHT ? "[found]" : "[not found — will use chrome-devtools MCP]"}
+  DESIGN.md:      {HAS_DESIGN_MD ? "[found — using as design system]" : "[not found — will use frontend-design skill]"}
 ```
 
 **If `HAS_PLAYWRIGHT = false`:**
-Output: `"Playwright CLI: ❌ not found — will use chrome-devtools MCP"`
-Output: `"💡 To enable playwright-cli: npm i -g @playwright/cli — see https://github.com/microsoft/playwright-cli"`
+Output: `"Playwright CLI: [not found — will use chrome-devtools MCP]"`
+Output: `"[i] To enable playwright-cli: npm i -g @playwright/cli — see https://github.com/microsoft/playwright-cli"`
 Proceed with chrome-devtools MCP fallback. Do NOT ask the user or install anything.
 
 **If `HAS_DESIGN_MD = false` and the project has UI:**
-Output: `"DESIGN.md: ❌ not found — will use frontend-design skill"`
-Output: `"💡 For better design: browse https://github.com/VoltAgent/awesome-design-md"`
+Output: `"DESIGN.md: [not found — will use frontend-design skill]"`
+Output: `"[i] For better design: browse https://github.com/VoltAgent/awesome-design-md"`
 Proceed with frontend-design skill fallback. Do NOT ask the user or install anything.
 
 **Pass these flags to every agent dispatch:**
@@ -253,21 +280,26 @@ noise that wastes context tokens.
 Wait for all generators to complete. **Generators now own the full pipeline** — each
 generator submits, reviews, approves, and merges its own changeset autonomously.
 
-**As each generator completes**, check its report status:
+**As each generator completes**, check its report status.
+
+**═══ OUTPUT FORMAT — EACH LINE ON ITS OWN ═══**
+Each generator completion must be output as a SEPARATE message/line. Do NOT concatenate
+multiple generator statuses into one block. Users read these as they stream in — one per
+line keeps the log readable.
 
 - **Status: merged** → record in `merged_units` with the merged_commit hash.
-  Output: `Generator **[unit-name]** MERGED — commit [hash], score [X/5]. Progress: N/M done.`
+  Output on its own line: `[unit-name] MERGED — commit [hash], score [X/5]. Progress: N/M done.`
 
 - **Status: blocked_timeout** → the generator couldn't acquire a symbol lock in time.
-  Output: `Generator **[unit-name]** BLOCKED_TIMEOUT — will re-dispatch. Progress: N/M done.`
+  Output on its own line: `[unit-name] BLOCKED_TIMEOUT — will re-dispatch. Progress: N/M done.`
 
 - **Status: review_failed** → the generator couldn't pass review after 10 rounds.
   Record in `merge_failures`.
-  Output: `Generator **[unit-name]** REVIEW_FAILED — local {X}/5, deep {Y}/5. Progress: N/M done.`
+  Output on its own line: `[unit-name] REVIEW_FAILED — local {X}/5, deep {Y}/5. Progress: N/M done.`
 
 - **Status: conflict_unresolved** → dk_merge conflict couldn't be self-resolved.
   Record in `merge_failures`.
-  Output: `Generator **[unit-name]** CONFLICT_UNRESOLVED. Progress: N/M done.`
+  Output on its own line: `[unit-name] CONFLICT_UNRESOLVED. Progress: N/M done.`
 
 - **No report / crashed** → record as failure.
 
@@ -322,10 +354,17 @@ The temp branch `dkh/sync-*` is cleaned up in Phase 5 after the final PR push.
 This is a hard gate — not optional. If the app crashes on startup, evaluators will waste
 tokens testing a broken app. Fix the build first.
 
-1. Install dependencies: `bun install`
-2. Start the dev server: `bun run dev`
-3. Wait for the server to be ready (check the port)
-4. **Verify the app loads** — use the detected browser tool:
+**═══ OUTPUT PROGRESS FOR EACH STEP ═══**
+Users watching the build have no visibility into the smoke test unless you output
+progress. Output a status line BEFORE each step:
+
+1. Output: `"Smoke test 1/5: installing dependencies..."` then `bun install`
+2. Output: `"Smoke test 2/5: starting dev server..."` then `bun run dev`, detect port, output: `"Dev server started at http://localhost:{port}"`
+3. Output: `"Smoke test 3/5: waiting for server to be ready..."` then poll the port
+4. Output: `"Smoke test 4/5: verifying app loads at {url}..."` then **verify with browser tool below**
+5. Output: `"Smoke test 5/5: checking console errors..."` then check console
+
+**Verify the app loads** — use the detected browser tool:
 
    **If `HAS_PLAYWRIGHT = true`:**
    ```bash
@@ -354,19 +393,49 @@ tokens testing a broken app. Fix the build first.
 - [ ] Screenshot shows actual content (not error overlay, not blank page)
 - [ ] No fatal JavaScript errors in console (warnings are OK, errors are NOT)
 
-**If smoke test FAILS** → The app doesn't start or crashes on load. This is a build
-failure, not an eval failure. DO NOT dispatch evaluators. **DO NOT fix code locally
-with Write/Edit/Bash** — all fixes must go through dkod (dk_connect → dk_file_write →
-dk_submit → dk_verify → dk_approve → dk_merge → dk_push branch → git checkout -B). Instead:
-- Kill the dev server
-- Treat ALL units as failed with feedback: "App crashes on startup: <error details>"
-- **Execute Round Transition** (see the "Round Transition" block below): increment `round`,
-  wipe `merged_units`, `merge_failures`, `eval_reports`
-- **Check round cap**: if `round >= 3` after incrementing, do NOT re-dispatch.
-  Instead, `dk_push` with "app fails to start after 3 rounds" documented. This matches
-  the Phase 4 RETRY round-3 behavior.
-- Re-dispatch all generators with the crash error as feedback
-- After fix round, re-land, **re-run FILE SYNC** (dk_push branch + git checkout), then re-run smoke test
+**If smoke test FAILS** → The app doesn't start or crashes on load.
+
+**═══ ABSOLUTE RULE: THE ORCHESTRATOR NEVER WRITES CODE ═══**
+You MUST NOT call `dk_connect`, `dk_file_write`, `dk_submit`, `dk_approve`, `dk_merge`,
+`dk_resolve`, `Write`, `Edit`, or `Bash` file redirects YOURSELF. EVER. Even for a
+"quick fix" or "just one file." All code changes go through sub-agents.
+
+**Fix-Integration Flow (parallel, symbol-owned):**
+
+1. **Analyze failures** — categorize errors by affected file/symbol:
+   - Import path errors → which files have broken imports
+   - Type mismatches → which types are incompatible
+   - Runtime errors → which module is crashing
+   - Data contract mismatches → which interface is wrong
+
+2. **Decompose into fix units** — group related fixes by symbol ownership (like the
+   planner does for the initial build). Each fix unit owns specific symbols so multiple
+   fix agents can run in parallel without conflict.
+
+3. **Dispatch parallel fix sub-agents** — ALL in a single message:
+   ```
+   for each fix_unit:
+     Agent(
+       subagent_type: "general-purpose",
+       model: <generator model from active profile>,
+       prompt: <generator.md instructions +
+               "FIX INTEGRATION: <error summary>" +
+               "Files to fix: <specific files>" +
+               "Symbols you own: <symbols>" +
+               "Expected outcome: <what should work after fix>" +
+               "CRITICAL: pass session_id on every dk_* call.">,
+       description: "Fix: <fix unit title>",
+       name: "fix-<fix-unit-id>"
+     )
+   ```
+
+4. **Wait for all fix agents to complete and merge** (they self-merge via streaming pipeline)
+
+5. **Re-run FILE SYNC + smoke test** with the fixed code
+
+6. **If smoke test fails again after fix round**:
+   - Increment `round`. If `round >= 3` → `dk_push` with "app fails to start after 3 rounds" documented
+   - Otherwise → analyze new errors, dispatch new fix sub-agents (repeat from step 1)
 
 **If smoke test PASSES** → Record the server URL. Proceed to Phase 4 (Eval).
 

--- a/skills/dkh/agents/orchestrator.md
+++ b/skills/dkh/agents/orchestrator.md
@@ -405,6 +405,9 @@ You MUST NOT call `dk_connect`, `dk_file_write`, `dk_submit`, `dk_approve`, `dk_
 
 **Fix-Integration Flow (parallel, symbol-owned):**
 
+0. **Kill the dev server** to free the port and release file handles:
+   `kill <PID>` or `pkill -f "bun run dev"`
+
 1. **Analyze failures** — categorize errors by affected file/symbol:
    - Import path errors → which files have broken imports
    - Type mismatches → which types are incompatible
@@ -437,6 +440,7 @@ You MUST NOT call `dk_connect`, `dk_file_write`, `dk_submit`, `dk_approve`, `dk_
 5. **Re-run FILE SYNC + smoke test** with the fixed code
 
 6. **If smoke test fails again after fix round**:
+   - Bulk-close all non-terminal changesets (same curl as Round Transition) to release symbol claims
    - Increment `round`. If `round >= 3` → `dk_push` with "app fails to start after 3 rounds" documented
    - Otherwise → analyze new errors, dispatch new fix sub-agents (repeat from step 1)
 

--- a/skills/dkh/agents/planner.md
+++ b/skills/dkh/agents/planner.md
@@ -418,7 +418,7 @@ across units:
 ### Data Types
 | Interface | Fields | Types | Owner | Used By |
 |-----------|--------|-------|-------|---------|
-| Task | id, title, description, status, columnId, order | string, string, string, 'todo'|'in-progress'|'done', string, number | WU-02 | WU-04, WU-05, WU-06 |
+| Task | id, title, description, status, columnId, order | string, string, string, 'todo' \| 'in-progress' \| 'done', string, number | WU-02 | WU-04, WU-05, WU-06 |
 | Column | id, name, order, boardId | string, string, number, string | WU-02 | WU-04, WU-05 |
 | Project | id, name, createdAt, updatedAt | string, string, string (ISO), string (ISO) | WU-02 | WU-01, WU-03 |
 

--- a/skills/dkh/agents/planner.md
+++ b/skills/dkh/agents/planner.md
@@ -400,6 +400,53 @@ this class of errors entirely.
 **Every generator receives this table.** When Unit 4 needs to import `useTaskStore`, it
 imports from `src/stores/useTaskStore.ts` — exactly as specified, no guessing.
 
+### Step 5d: Build the Shared Contracts
+
+The File Manifest tells generators WHERE to import, but not WHAT the symbols look like.
+Without shared contracts, parallel generators produce mismatches like:
+- Snake_case vs camelCase field names (API returns `project_id`, UI expects `projectId`)
+- Wrong arg counts (`moveCard` called with 4 args, defined to take 3)
+- Type mismatches (types say `number`, runtime gets `string`)
+- Property name mismatches (`isLoading` vs `loading`)
+
+**Add a Shared Contracts section** defining exact shapes for every interface shared
+across units:
+
+```
+## Shared Contracts
+
+### Data Types
+| Interface | Fields | Types | Owner | Used By |
+|-----------|--------|-------|-------|---------|
+| Task | id, title, description, status, columnId, order | string, string, string, 'todo'|'in-progress'|'done', string, number | WU-02 | WU-04, WU-05, WU-06 |
+| Column | id, name, order, boardId | string, string, number, string | WU-02 | WU-04, WU-05 |
+| Project | id, name, createdAt, updatedAt | string, string, string (ISO), string (ISO) | WU-02 | WU-01, WU-03 |
+
+### Store Functions
+| Function | Signature | Owner | Used By |
+|----------|-----------|-------|---------|
+| useTaskStore().createTask | (task: Omit<Task, 'id'>) => Promise<Task> | WU-02 | WU-04, WU-06 |
+| useTaskStore().moveCard | (taskId: string, toColumnId: string, toOrder: number) => Promise<void> | WU-02 | WU-05 |
+
+### API Response Shapes
+| Endpoint | Response | Owner |
+|----------|----------|-------|
+| GET /api/tasks | { tasks: Task[] } | WU-02 |
+| POST /api/tasks | { task: Task } | WU-02 |
+```
+
+**Rules:**
+1. **Exact field names** — if the API returns `project_id` (snake_case), document it;
+   or require camelCase transformation in the API layer
+2. **Exact types** — no hand-waving. `string` not "identifier". `Date` vs `string (ISO)` matters.
+3. **Function signatures** — arg count, arg types, return type — all explicit
+4. **Property name consistency** — decide `isLoading` OR `loading`, then use it everywhere
+
+**Naming convention rule:** Pick ONE convention in the Shared Contracts and enforce it:
+- DB fields: snake_case (common SQL convention)
+- TypeScript: camelCase
+- If using both, document where conversion happens (typically in the API layer)
+
 ### Step 6: Define Acceptance Criteria
 
 For each work unit, define testable criteria the evaluator will check:
@@ -514,3 +561,11 @@ session and prevents it from appearing as an orphaned draft changeset.
    that opens the TaskForm modal" is useful.
 6. **Don't over-specify implementation.** Define WHAT to build and WHERE (which symbols/files),
    not HOW. Generators are smart — let them make implementation choices.
+7. **Stack-specific rules:**
+   - **If using Bun**: always specify `bun:sqlite` for SQLite. NEVER `better-sqlite3` or
+     `sqlite3` — they require native compilation and fail on many systems. `bun:sqlite`
+     is built into Bun with no native deps.
+   - **If using Node**: `better-sqlite3` is fine (native compiles usually work in Node).
+8. **Shared Contracts section is MANDATORY** when units share data or function signatures.
+   Without it, generators produce snake_case vs camelCase mismatches, wrong arg counts,
+   and property name typos that only surface during integration.


### PR DESCRIPTION
## Summary

Six comprehensive fixes addressing issues observed during the 2026-04-12 autonomous build session.

### CRITICAL fixes

**1. Orchestrator MUST NOT write code**
Added absolute rule at the top of orchestrator.md. The orchestrator was connecting to dkod itself (`dk_connect` with its own session) and fixing integration issues directly via `dk_file_write` → `dk_submit` → `dk_approve` → `dk_merge`. This burned the orchestrator's 200-turn context on debug loops. Now explicitly forbidden for dk_connect, dk_file_write, dk_file_read, dk_submit, dk_approve, dk_merge, dk_resolve, Write, Edit, and Bash file redirects.

**2. Parallel fix-integration flow**
On smoke test failure, the orchestrator now decomposes errors by symbol ownership and dispatches N parallel fix sub-agents (same pattern as Phase 2 generators). Previously re-dispatched ALL generators for a full round — wasteful. Now only spawns fix agents for the specific failures, in parallel.

### HIGH fixes

**3. Shared Contracts in planner output**
New Step 5d adds a Shared Contracts section defining exact:
- Field names and types for shared data interfaces
- Function signatures with arg counts
- API response shapes
- Naming convention rules (camelCase vs snake_case, with conversion layer)

Prevents the class of integration bugs we observed (`project_id` vs `projectId`, `moveCard(4 args)` vs `moveCard(3 args)`, `isLoading` vs `loading`).

**4. Stack-specific rules (bun:sqlite)**
Planner must use `bun:sqlite` (built-in) when stack is Bun, never `better-sqlite3` (requires native compilation). Observed failure during smoke test.

**5. Evaluator must respect HAS_PLAYWRIGHT**
Added explicit warning at the top of evaluator.md — evaluator was defaulting to chrome-devtools despite `playwright-cli` being detected and the flag being passed.

### UX fixes

**6. Output formatting**
- Each generator progress line on its own line (was concatenated into one wall of text)
- Smoke test outputs step-by-step progress (5 steps with status lines) — was silent for minutes
- Replaced heavy emoji with plain text markers (`[found]`, `[not found]`, `[i]`)

## Test plan

- [ ] Run parallel build — orchestrator never calls dk_connect/dk_file_write itself
- [ ] Smoke test failure dispatches fix sub-agents (not orchestrator fixing)
- [ ] Planner produces Shared Contracts section
- [ ] Planner uses bun:sqlite when stack is Bun
- [ ] Evaluator uses playwright-cli when HAS_PLAYWRIGHT=true
- [ ] Generator progress lines are separate, smoke test shows step-by-step progress