### PR TITLE
fix: strengthen generator deep review gate + handle deep-review-disabled

### DIFF
--- a/skills/dkh/agents/generator.md
+++ b/skills/dkh/agents/generator.md
@@ -242,6 +242,7 @@ Before entering the loop, output:
 ```
 round = 1                    # the dk_submit you just did
 deep_review_disabled = false # set to true if the disabled branch is taken
+deep_score = null            # set from review_result when deep review is present
 
 LOOP while round ≤ 10:
 

--- a/skills/dkh/agents/generator.md
+++ b/skills/dkh/agents/generator.md
@@ -227,13 +227,17 @@ If verify fails, fix the issues and re-submit (counts as a round).
 **5c. Review-Fix Loop (max 10 rounds)**
 
 **═══ MERGE QUALITY GATES — CRITICAL ═══**
-- **Local review score: must be ≥ 4/5** to proceed to deep review
-- **Deep review score: must be ≥ 4/5** to exit the loop
+- **Local review score: must be ≥ 4/5** (always enforced)
+- **Deep review score: must be ≥ 4/5** (only when deep review is enabled for the repo)
 - Changesets that don't meet these thresholds MUST NOT be merged.
-  Keep fixing until you reach 4/5 deep or exhaust 10 rounds.
+
+**═══ DEEP REVIEW MAY BE DISABLED ═══**
+Deep review requires the repo to have an Anthropic/OpenRouter API key configured.
+If disabled, `dk_review` returns no deep findings (deep_score is null/absent). In that
+case, skip the deep review gate entirely — local review is the only gate.
 
 Before entering the loop, output:
-> Starting review-fix loop (max 10 rounds) — target: local ≥ 4/5, deep ≥ 4/5
+> Starting review-fix loop (max 10 rounds) — target: local ≥ 4/5, deep ≥ 4/5 (if enabled)
 
 ```
 round = 1   (the dk_submit you just did)
@@ -252,9 +256,17 @@ LOOP while round ≤ 10:
     continue
 
   # ═══ LOCAL IS CLEAN (≥ 4/5) — CHECK DEEP REVIEW ═══
-  dk_watch(filter: "changeset.review.completed", wait: true)
-  dk_review(changeset_id) → get deep findings + score
+  # MUST wait for deep review BEFORE proceeding. Don't skip this.
+  # If deep review is disabled on the repo, dk_watch returns quickly or
+  # dk_review returns no deep findings — treat as "deep review disabled".
+  dk_watch(filter: "changeset.review.completed", wait: true, timeout_ms: 300000)
+  review_result = dk_review(changeset_id)
 
+  if review_result has no deep review (disabled):
+    OUTPUT: "Deep review disabled — local review: {local_score}/5 is the only gate. Proceeding after {round} round(s)."
+    break  (proceed to approve + merge — local-only gate)
+
+  # Deep review exists — enforce the gate
   if deep_score >= 4 AND no severity:"error" findings:
     OUTPUT: "Review complete — local: {local_score}/5, deep: {deep_score}/5 after {round} round(s)"
     break  (proceed to approve + merge)
@@ -271,8 +283,10 @@ LOOP while round ≤ 10:
 ```
 
 **Max-rounds fallback:** If 10 rounds exhausted:
-- If local ≥ 4/5 AND deep ≥ 3/5 → proceed to approve + merge with warning
-- Otherwise → report as `review_failed`, do NOT merge
+- If deep review disabled: if local ≥ 4/5 → proceed to approve + merge. Otherwise → `review_failed`.
+- If deep review enabled: if local ≥ 4/5 AND deep ≥ 3/5 → proceed to approve + merge with warning. Otherwise → `review_failed`.
+
+**CRITICAL — do NOT skip the deep review wait.** The previous build observed changesets merging with deep 2/5 because generators called dk_approve/dk_merge immediately after dk_submit without waiting for the async deep review. ALWAYS call `dk_watch(wait: true)` before `dk_review`, and ALWAYS enforce the deep gate when a deep score exists.
 
 **CRITICAL: Fix ALL findings before submitting.** Each submit costs a round. Read all
 findings → plan all fixes → apply all fixes → submit once.

--- a/skills/dkh/agents/generator.md
+++ b/skills/dkh/agents/generator.md
@@ -269,10 +269,19 @@ LOOP while round ≤ 10:
 
   review_result = dk_review(changeset_id)
 
-  if review_result has no deep review (disabled):
-    deep_review_disabled = true
-    OUTPUT: "Deep review disabled — local: {local_score}/5 is the only gate. Proceeding after {round} round(s)."
-    break  (proceed to approve + merge — local-only gate)
+  if review_result has no deep review:
+    if deep_score is not null (seen in a prior round):
+      # Deep review WAS working — treat as transient error, retry
+      OUTPUT: "WARNING: Deep review returned no score this round (transient?). Retrying."
+      round += 1
+      if round > 10 → break
+      dk_submit(intent)
+      continue
+    else:
+      # Never seen a deep score — treat as disabled for this repo
+      deep_review_disabled = true
+      OUTPUT: "Deep review disabled — local: {local_score}/5 is the only gate. Proceeding after {round} round(s)."
+      break  (proceed to approve + merge — local-only gate)
 
   # Deep review exists — enforce the gate
   if deep_score >= 4 AND no severity:"error" findings:

--- a/skills/dkh/agents/generator.md
+++ b/skills/dkh/agents/generator.md
@@ -240,7 +240,8 @@ Before entering the loop, output:
 > Starting review-fix loop (max 10 rounds) — target: local ≥ 4/5, deep ≥ 4/5 (if enabled)
 
 ```
-round = 1   (the dk_submit you just did)
+round = 1                    # the dk_submit you just did
+deep_review_disabled = false # set to true if the disabled branch is taken
 
 LOOP while round ≤ 10:
 
@@ -255,15 +256,22 @@ LOOP while round ≤ 10:
     dk_submit again
     continue
 
-  # ═══ LOCAL IS CLEAN (≥ 4/5) — CHECK DEEP REVIEW ═══
+  # ═══ LOCAL IS CLEAN (≥ 4/5) — WAIT FOR DEEP REVIEW ═══
   # MUST wait for deep review BEFORE proceeding. Don't skip this.
-  # If deep review is disabled on the repo, dk_watch returns quickly or
-  # dk_review returns no deep findings — treat as "deep review disabled".
-  dk_watch(filter: "changeset.review.completed", wait: true, timeout_ms: 300000)
+  watch_result = dk_watch(filter: "changeset.review.completed", wait: true, timeout_ms: 300000)
+
+  if watch_result.timed_out:
+    OUTPUT: "WARNING: Deep review timed out after 5 min — cannot enforce deep gate this round. Fixing and resubmitting to retry."
+    round += 1
+    if round > 10 → break
+    dk_submit(intent)
+    continue
+
   review_result = dk_review(changeset_id)
 
   if review_result has no deep review (disabled):
-    OUTPUT: "Deep review disabled — local review: {local_score}/5 is the only gate. Proceeding after {round} round(s)."
+    deep_review_disabled = true
+    OUTPUT: "Deep review disabled — local: {local_score}/5 is the only gate. Proceeding after {round} round(s)."
     break  (proceed to approve + merge — local-only gate)
 
   # Deep review exists — enforce the gate
@@ -283,8 +291,8 @@ LOOP while round ≤ 10:
 ```
 
 **Max-rounds fallback:** If 10 rounds exhausted:
-- If deep review disabled: if local ≥ 4/5 → proceed to approve + merge. Otherwise → `review_failed`.
-- If deep review enabled: if local ≥ 4/5 AND deep ≥ 3/5 → proceed to approve + merge with warning. Otherwise → `review_failed`.
+- If `deep_review_disabled`: if local ≥ 4/5 → proceed to approve + merge. Otherwise → `review_failed`.
+- Otherwise (deep review enabled): if local ≥ 4/5 AND deep ≥ 3/5 → proceed to approve + merge with warning. Otherwise → `review_failed`.
 
 **CRITICAL — do NOT skip the deep review wait.** The previous build observed changesets merging with deep 2/5 because generators called dk_approve/dk_merge immediately after dk_submit without waiting for the async deep review. ALWAYS call `dk_watch(wait: true)` before `dk_review`, and ALWAYS enforce the deep gate when a deep score exists.
 

--- a/skills/dkh/agents/generator.md
+++ b/skills/dkh/agents/generator.md
@@ -284,6 +284,10 @@ LOOP while round ≤ 10:
       OUTPUT: "Deep review disabled — local: {local_score}/5 is the only gate. Proceeding after {round} round(s)."
       break  (proceed to approve + merge — local-only gate)
 
+  # Deep review present — record the score (persists across rounds so the
+  # transient-vs-disabled check above works on any future missing-deep round)
+  deep_score = review_result.deep_score
+
   # Deep review exists — enforce the gate
   if deep_score >= 4 AND no severity:"error" findings:
     OUTPUT: "Review complete — local: {local_score}/5, deep: {deep_score}/5 after {round} round(s)"


### PR DESCRIPTION
## Summary

Strengthens the generator's review-fix loop to guarantee deep review is actually waited for and enforced — addressing the 2/5 merge issue observed in the last build session. Also handles the case where deep review is disabled (no API key), since deep review is a harness-only feature and some dkod users won't have it enabled.

## Changes

1. **Explicit deep-review-disabled handling** — if `dk_review` returns no deep findings, treat as disabled and proceed with local-only gate (still requires local >= 4/5)
2. **Timeout on dk_watch** — 5 min timeout prevents indefinite block if review never completes
3. **Max-rounds fallback branches** — disabled vs enabled paths
4. **CRITICAL warning** — do NOT skip dk_watch; previous build saw 2/5 merges from racing past async review

## Why harness-side (not platform)

Deep review requires an Anthropic/OpenRouter API key and is a harness-only feature. Gating `dk_approve` at the platform level would reject legitimate approvals from regular dkod users (no harness) who don't have deep review enabled.

## Test plan

- [ ] Run build with deep review enabled — generators wait for deep review, enforce >= 4/5
- [ ] Run build with deep review disabled — generators proceed with local-only gate
- [ ] No more 2/5 merges when deep review is enabled