### PR TITLE
fix: reject empty changesets at generator pre-submit

### DIFF
--- a/skills/dkh/agents/generator.md
+++ b/skills/dkh/agents/generator.md
@@ -216,6 +216,20 @@ Before calling `dk_submit`, verify:
 1. **No unresolved conflict_warnings** — if any remain, go back to Step 3
 2. **`dk_watch()` final check** — verify your imports still match what other generators created
 3. **Self-review** — all acceptance criteria addressed, exports match spec
+4. **Changeset is NOT empty** — confirm you called `dk_file_write` at least once this
+   round AND at least one write succeeded. If you made zero successful writes:
+   - **DO NOT call `dk_submit`.** An empty changeset creates a deadlocked record on
+     the platform that can only be closed manually.
+   - **Diagnose why you have nothing to write.** Common causes:
+     - Work unit is already implemented by another generator's earlier merge (dkod's
+       AST overlay means files may already contain your target symbols at the current base).
+     - You're in a retry round and a prior attempt's work landed via salvage.
+     - You read files expecting to modify them and everything was already correct.
+   - **Report back immediately** with:
+     `Status: empty_changeset — work unit appears already implemented at base [sha7].
+     Rejecting empty submit.`
+     The orchestrator will treat this as a soft success (no work needed) and will NOT
+     re-dispatch. Do not call `dk_close` — session cleanup is the orchestrator's job.
 
 ### Step 5: Submit, Review, and Merge — FULL PIPELINE
 

--- a/skills/dkh/agents/orchestrator.md
+++ b/skills/dkh/agents/orchestrator.md
@@ -322,18 +322,27 @@ line keeps the log readable.
   Record in `merge_failures`.
   Output on its own line: `[unit-name] CONFLICT_UNRESOLVED. Progress: N/M done.`
 
+- **Status: empty_changeset** → the generator detected there is nothing to submit
+  (the work unit's files are already present at the current base — typically landed
+  by another unit's merge or a prior salvage). Record in `merged_units` as a no-op
+  success and do NOT re-dispatch — re-dispatching would loop on the same empty state.
+  Output on its own line: `[unit-name] EMPTY_CHANGESET — already implemented at base. Progress: N/M done.`
+
 - **No report / crashed** → record as failure.
 
 **═══ GATE 2 CHECK ═══**
 Before proceeding, verify:
 - [ ] Every generator has reported back
-- [ ] Count `merged` vs `blocked_timeout` / `review_failed` / `conflict_unresolved`
-- [ ] At least one generator merged successfully
+- [ ] Count `merged` + `empty_changeset` (both count as done) vs `blocked_timeout` / `review_failed` / `conflict_unresolved`
+- [ ] At least one generator merged successfully (or all remaining units are `empty_changeset`)
 
 **If any generators are blocked_timeout or conflict_unresolved:**
 - Increment `unit_attempts[unit_id]`
 - If `unit_attempts[unit_id] >= 3` → move to `blocked_units`, remove from `active_units`
 - Otherwise → re-dispatch
+
+**`empty_changeset` is NOT retried** — the work unit is already satisfied at the
+current base. Treat it as done.
 
 **If any generators crashed** (no report at all):
 - Re-dispatch. Do NOT proceed until all have reported.


### PR DESCRIPTION
## Problem

When a generator is re-dispatched on conflict_unresolved (or any retry path), the work unit's target files may already be present at the current base — landed by another generator's merge or a prior salvage. The generator reads them, sees they're already correct, writes nothing, then **still calls \`dk_submit\`**, producing a changeset with zero files. The platform has no guard against empty submits: it accepts the record and the result is a deadlocked \`conflicted:detected\` state that only manual close can resolve.

Observed: \`dkod-io/project-management-demo\` #58 ("WU-06: retry merge of Comments & Activity Feed") — zero files, stuck.

## Fix

**Generator (\`skills/dkh/agents/generator.md\`)** — add Step 4 item 4: before \`dk_submit\`, verify at least one \`dk_file_write\` succeeded this round. If zero, do NOT submit. Report \`Status: empty_changeset\` with a diagnosis (work already at base / salvaged / no-op) and exit.

**Orchestrator (\`skills/dkh/agents/orchestrator.md\`)** — add \`empty_changeset\` as a recognized terminal status. It counts as done (alongside \`merged\`), is recorded in \`merged_units\`, and is **not** re-dispatched (re-dispatching would loop on the same empty state).

## Test plan

- [ ] Manual: trigger a retry scenario where the target files are already landed (e.g., two generators on overlapping symbols, second retries after first merges). Verify the second reports \`empty_changeset\` and the orchestrator logs it as done without re-dispatching.
- [ ] Review log: no new \`#XX conflicted:detected, 0 files\` rows in platform DB.

## Follow-up

Platform-side defense-in-depth would also be good: \`dk_submit\` should reject a changeset with zero \`changeset_files\` rows at the API boundary. Separate PR.