### PR TITLE
orchestrator: circuit-break on dk_merge platform errors + halt manifest

### DIFF
--- a/skills/dkh/agents/generator.md
+++ b/skills/dkh/agents/generator.md
@@ -445,7 +445,7 @@ After merge (or failure), report back to the orchestrator and **exit immediately
 ```
 
 **Template E — Platform merge error (preserved changeset):**
-```
+```markdown
 ## Generator Report: <unit title>
 
 **Status:** merge_failed_platform

--- a/skills/dkh/agents/generator.md
+++ b/skills/dkh/agents/generator.md
@@ -368,6 +368,24 @@ result = dk_merge(changeset_id, message: "<unit title>")
   ```
   If you also receive `changeset.parent_rollback_invalidated`, your parent failed
   merge. Close + report the unit for re-planning (don't retry blindly).
+- **MergePlatformError** → `dk_merge` failed with a platform-side error, not a
+  conflict. Signals: HTTP 5xx on the merge call; error strings containing
+  "does not exist", "internal error", "database", "schema", "timeout", or "evicted";
+  session eviction notifications fired mid-merge; any non-success response that is
+  neither MergeConflict nor MERGE_BLOCKED.
+  - Do **NOT** retry — retrying against a broken merge pipeline only creates more
+    stuck changesets and orphaned symbol locks.
+  - Do **NOT** call `dk_close` — keeping the session alive preserves your approved
+    changeset and prevents your symbol claims from orphaning. The orchestrator
+    decides when to clean up.
+  - Exit with `Status: merge_failed_platform`, including the changeset_id, the
+    review scores you already achieved, and the raw error from `dk_merge`.
+
+  When uncertain between MergeConflict and MergePlatformError, prefer the latter.
+  The orchestrator has a circuit-breaker for platform errors: misclassifying a
+  conflict as platform only halts one run, while misclassifying a platform error
+  as a conflict lets the harness burn its remaining generators against a broken
+  platform.
 
 The `dk_merge` response includes step-by-step instructions when conflicts occur.
 
@@ -426,7 +444,24 @@ After merge (or failure), report back to the orchestrator and **exit immediately
 **Notes:** <what was tried>
 ```
 
-**After outputting your report, call `dk_close(session_id)` and exit.**
+**Template E — Platform merge error (preserved changeset):**
+```
+## Generator Report: <unit title>
+
+**Status:** merge_failed_platform
+**Session ID:** <from dk_connect response>   ← KEEP ALIVE, do NOT dk_close
+**Changeset ID:** <from dk_submit response>  ← in `approved` state; ready to merge when platform recovers
+**Final review score:** local {X}/5, deep {Y}/5
+**Rounds used:** <count>
+**Error class:** <one of: db_schema_error | http_5xx | session_evicted_mid_merge | malformed_response | unknown_platform>
+**Error message:** <raw error from the dk_merge response>
+**Notes:** Session kept open to preserve symbol claims and the approved changeset. Do NOT re-dispatch this unit — work is complete; only the merge call failed.
+```
+
+**After outputting your report, call `dk_close(session_id)` and exit — with one
+exception: if your status is `merge_failed_platform`, do NOT call `dk_close`. Exit
+with the session still open so the approved changeset and its symbol claims are
+preserved for platform-side recovery.**
 
 ## When You're Re-Dispatched (Fix Round)
 
@@ -447,3 +482,6 @@ submit → verify → review-fix → approve → merge.
 4. **Be fast.** The build waits for the slowest generator. Parallelize file reads.
 5. **No package installs.** Orchestrator handles deps.
 6. **Bash timeout.** If you must run Bash, always prefix with `timeout 30`.
+7. **Never retry or `dk_close` on a platform merge error.** Classify as
+   `merge_failed_platform`, preserve the session, and let the orchestrator's
+   circuit-breaker decide.

--- a/skills/dkh/agents/orchestrator.md
+++ b/skills/dkh/agents/orchestrator.md
@@ -114,6 +114,8 @@ eval_reports: []            # Set after Phase 3 — MUST EXIST before dk_push
 unit_attempts: {}           # { "unit-id": attempt_count } — incremented each re-dispatch
 blocked_units: []           # Units that exceeded MAX_UNIT_ATTEMPTS (3) — not retried
 replan_count: 0             # Number of REPLANs executed this build (max 1)
+platform_halt: false        # Circuit-breaker — flips true on first merge_failed_platform report
+halt_manifest_path: null    # Path to the halt manifest once written (set when platform_halt is tripped)
 ```
 
 ---
@@ -322,6 +324,16 @@ line keeps the log readable.
   Record in `merge_failures`.
   Output on its own line: `[unit-name] CONFLICT_UNRESOLVED. Progress: N/M done.`
 
+- **Status: merge_failed_platform** → the generator was reviewed and approved,
+  but `dk_merge` failed with a platform-side error (DB error, 5xx, session evicted
+  mid-merge, malformed response). The changeset is in `approved` state and the
+  generator has KEPT its session open to preserve symbol claims. This is **NOT**
+  retryable and **NOT** a conflict. Record in `merge_failures` with the
+  changeset_id, review scores, and error class/message. **Set `platform_halt = true`**
+  — this short-circuits the remaining Gate 2 logic. Do NOT increment `unit_attempts`;
+  the unit's work is complete, only the merge call failed.
+  Output on its own line: `[unit-name] MERGE_FAILED_PLATFORM — changeset [id] approved (local {X}/5, deep {Y}/5). Platform halt engaged.`
+
 - **Status: empty_changeset** → the generator detected there is nothing to submit
   (the work unit's files are already present at the current base — typically landed
   by another unit's merge or a prior salvage). Record in `merged_units` as a no-op
@@ -333,8 +345,35 @@ line keeps the log readable.
 **═══ GATE 2 CHECK ═══**
 Before proceeding, verify:
 - [ ] Every generator has reported back
-- [ ] Count `merged` + `empty_changeset` (both count as done) vs `blocked_timeout` / `review_failed` / `conflict_unresolved`
+- [ ] **Platform halt check:** if `platform_halt == true` (any generator reported
+  `merge_failed_platform`), STOP. Write the halt manifest (see **HALT MANIFEST**
+  section below), output the halt message, and exit the run. **Skip every other
+  Gate 2 branch** — no retries, no bulk-close, no re-dispatch.
+- [ ] Count `merged` + `empty_changeset` (both count as done) vs `blocked_timeout` / `review_failed` / `conflict_unresolved` / `merge_failed_platform`
 - [ ] At least one generator merged successfully (or all remaining units are `empty_changeset`)
+
+**═══ PLATFORM HALT (circuit-breaker) ═══**
+
+If `platform_halt == true`:
+
+1. **Do NOT bulk-close.** The approved changesets in `merge_failures` represent real,
+   reviewed work. Bulk-close would destroy them. Other generators still in-flight
+   that reach `dk_merge` against the broken platform will also report
+   `merge_failed_platform` — collect their reports but do not retry any of them.
+2. **Write the halt manifest** (see below). Set `halt_manifest_path` on the state.
+3. **Output** (each line standalone):
+   ```
+   🛑 Harness halted — platform merge failure detected.
+   Halt manifest: <halt_manifest_path>
+   Approved changesets preserved: <N>
+   Do NOT /dkh continue until the platform is recovered.
+   ```
+4. **Exit the run.** Do not proceed to FILE SYNC / SMOKE TEST / EVAL / SHIP.
+
+**`platform_halt` is a one-way gate.** Once set, the orchestrator cannot clear it
+in the same run — a fresh `/dkh` invocation (after platform recovery) is required.
+
+**If `platform_halt == false`:**
 
 **If any generators are blocked_timeout or conflict_unresolved:**
 - Increment `unit_attempts[unit_id]`
@@ -359,6 +398,72 @@ Bash: curl -sf -X POST "https://api.dkod.io/api/repos/<owner>/<repo>/changesets/
 > **Gate 2 PASSED** — `merged_units: [N]`, `merge_failures: [list or empty]`. Proceeding to FILE SYNC.
 
 ⚠️ **DO NOT dk_push after build. Shipping is Phase 4 only.**
+
+---
+
+### HALT MANIFEST — Platform Failure Recovery
+
+When `platform_halt == true`, the orchestrator writes a structured manifest that
+captures every approved changeset and its provenance so a platform operator can
+complete the merges manually (or resume via `/dkh continue` after platform recovery).
+
+**Path:** `docs/harness/runs/halt-<ISO-timestamp>.md` (e.g., `halt-2026-04-21T14-32-00Z.md`).
+If the `docs/harness/runs/` directory does not exist, create it via a sub-agent
+dispatch (orchestrator never writes files directly). In practice, dispatch a single
+general-purpose agent with a tight prompt: "Write the following manifest content to
+`<path>` using the `Write` tool. Do not touch anything else."
+
+**Required fields:**
+
+```markdown
+# Harness Halt Manifest
+
+- **Timestamp (UTC):** <ISO-8601>
+- **Repo:** <owner/repo>
+- **Harness version:** <SKILL.md version>
+- **Run ID / session context:** <short identifier>
+- **Halt reason:** platform merge failure (`merge_failed_platform` reported by ≥1 generator)
+
+## Approved changesets (preserve — DO NOT bulk-close)
+
+| Unit | Changeset ID | State | Local score | Deep score | Session ID (still open) | Error class | Error message |
+|------|-------------|-------|------------|-----------|-------------------------|-------------|---------------|
+| WU-01 … | … | approved | 5/5 | 4/5 | <session_id> | db_schema_error | column "parent_changeset_id" does not exist |
+| …    | …           | …     | …          | …         | …                       | …           | …             |
+
+## Submitted changesets (reviewed but not approved)
+
+| Unit | Changeset ID | State | Local score | Deep score | Notes |
+|------|-------------|-------|------------|-----------|-------|
+
+## Incomplete / evicted units
+
+| Unit | Last known state | Evidence |
+|------|-----------------|----------|
+
+## Suggested recovery (platform side)
+
+1. Restore the broken platform component (in this outage: add the missing
+   `parent_changeset_id` column to the changesets table).
+2. Force-release any orphaned symbol locks held by evicted sessions listed above.
+3. Merge the approved changesets in dependency order (aggregation symbols / design
+   foundation units first). The harness has no authority to force this — a platform
+   operator must drive the merge.
+4. Once the repo's main branch reflects the merged state, the user can invoke
+   `/dkh continue` to resume from FILE SYNC.
+
+## DO NOT
+
+- Bulk-close the approved or submitted changesets above — they contain real,
+  reviewed work.
+- Re-dispatch these units before platform recovery — retries against a broken
+  merge pipeline create additional stuck changesets and orphaned locks.
+```
+
+Write-once semantics: the orchestrator writes this manifest a single time per run,
+on the first transition of `platform_halt` from `false` → `true`. Subsequent
+generator reports of `merge_failed_platform` in the same run append rows but do
+not create new manifests.
 
 ---
 
@@ -766,7 +871,15 @@ Total rounds: {rounds}
 ## Error Recovery
 
 - **Generator crashes**: Re-dispatch that single generator. Do not restart the entire build.
-- **dk_merge fails repeatedly**: Skip that changeset, note it in the eval.
+- **dk_merge conflict fails repeatedly** (non-platform): Skip that changeset, note it in the eval.
+  This is the conflict-path failure — `conflict_unresolved` after max self-resolve attempts.
+  Do NOT confuse with the platform-error path below.
+- **dk_merge reports `merge_failed_platform`** (platform-side DB error, 5xx, session
+  evicted mid-merge): the orchestrator trips `platform_halt` and executes the halt
+  manifest flow (see **HALT MANIFEST** in Phase 2). Do NOT bulk-close approved
+  changesets, do NOT re-dispatch, do NOT `dk_close` sessions for units in this state
+  — the generators themselves have already kept their sessions alive to preserve
+  symbol claims. Exit the run cleanly and wait for platform recovery.
 - **Dev server won't start (smoke test fails)**: This is a build failure, not an eval
   issue. DO NOT produce a "degraded eval report" — that is cheating. Instead: treat all
   units as failed, enter a fix round with the crash error as feedback, re-dispatch

--- a/skills/dkh/agents/orchestrator.md
+++ b/skills/dkh/agents/orchestrator.md
@@ -362,7 +362,7 @@ If `platform_halt == true`:
    `merge_failed_platform` — collect their reports but do not retry any of them.
 2. **Write the halt manifest** (see below). Set `halt_manifest_path` on the state.
 3. **Output** (each line standalone):
-   ```
+   ```text
    🛑 Harness halted — platform merge failure detected.
    Halt manifest: <halt_manifest_path>
    Approved changesets preserved: <N>


### PR DESCRIPTION
## Why

A recent `/dkh` run (7-unit React app build) hit a dkod platform regression: `dk_merge` threw a DB schema error (`column "parent_changeset_id" does not exist`), which triggered session eviction mid-merge, which orphaned every symbol lock that generator held. The harness had no classification for "platform failure" on dk_merge — the error fell through as something between `conflict_unresolved` and a crash. The downstream damage:

- Generators retried against a broken pipeline, piling up more stuck changesets.
- Gate 2's "zero merges → bulk-close everything" recovery path would have destroyed 4 approved-and-reviewed changesets (real work).
- The user had to manually reconstruct the list of approved changesets + review scores + session IDs from the failed run to hand to the platform team.

## What this PR adds

### 1. Generator-side classification — `generator.md`

- New `MergePlatformError` case in Step 5d with explicit signals (HTTP 5xx, error substrings, session-evicted-mid-merge, malformed non-conflict responses).
- On platform error: **no retries**, **no `dk_close`** (keep session alive to preserve symbol claims and the approved changeset).
- New report **Template E** with `merge_failed_platform` status, error class, error message, review scores, and a note that the session stays open.
- New Rule 7: never retry/close on platform merge errors.

### 2. Orchestrator-side circuit-breaker — `orchestrator.md`

- New state fields: `platform_halt` (bool), `halt_manifest_path` (path).
- New Gate 2 status: `merge_failed_platform` → trips `platform_halt`.
- Gate 2 check gains a **first-priority platform-halt branch** that short-circuits every other path (no retries, no bulk-close, no re-dispatch).
- New **HALT MANIFEST** section — writes `docs/harness/runs/halt-<ISO-ts>.md` via a sub-agent (orchestrator never writes files directly), listing every approved/submitted changeset, review scores, session IDs, and suggested platform-side recovery steps.
- Error Recovery section split: `conflict_unresolved` (existing behavior) vs `merge_failed_platform` (new halt flow).

### 3. What this intentionally does NOT change

- The "zero merges → bulk-close all non-terminal" recovery path stays exactly as it was for the non-platform failure mode. Bulk-close scope correction (P1 item #6 from the audit) is out of scope for this PR.
- `/dkh continue` semantics unchanged. A follow-up PR can teach continue to recognize halt manifests.
- Pre-flight merge smoke test (P0 item #4) is a separate follow-up PR.

## Why this is docs-only

The harness is a skill: the "code" is the prompt text that instructs the orchestrator and generator sub-agents. CodeRabbit does not meaningfully review markdown, so this PR is going straight to Greptile review. Nothing executes until the skill is invoked, so the blast radius of a docs regression is the next `/dkh` run.

## Test plan

- [ ] Greptile review passes at 5/5
- [ ] Next `/dkh` run: verify the first `merge_failed_platform` report triggers a halt manifest at `docs/harness/runs/halt-*.md` and the orchestrator exits without bulk-closing approved changesets
- [ ] Halt manifest format matches the template in `orchestrator.md` (fields, tables, recovery section)
- [ ] Generators classify a simulated `dk_merge` 500 response as `merge_failed_platform`, not `conflict_unresolved`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic "platform halt" behavior for platform-side merge failures: affected runs stop further retries/closures and preserve approved changes for recovery.
  * Reporting now captures platform merge details (session ID, approved changeset, final review, error class/message) for operator recovery.

* **Documentation**
  * Added guidance for halt manifests and recovery steps distinguishing platform merge failures from ordinary merge conflicts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->