### PR TITLE
orchestrator: add pre-flight dk_merge smoke test

### DIFF
--- a/skills/dkh/agents/orchestrator.md
+++ b/skills/dkh/agents/orchestrator.md
@@ -161,6 +161,103 @@ Bash: curl -sf -X POST "https://api.dkod.io/api/repos/<owner>/<repo>/changesets/
   -d '{"states": ["draft", "submitted", "approved", "rejected"], "created_before": "'$(date -u +%Y-%m-%dT%H:%M:%SZ)'"}'
 ```
 
+### Pre-Flight Merge Smoke Test — RUN ONCE BEFORE PLANNING
+
+**Why this exists:** A prior `/dkh` run burned 7 parallel Opus generators
+(~30 min of model budget) before the first `dk_merge` call surfaced a
+platform-side DB schema regression. A trivial round-trip through the merge
+pipeline here catches that class of outage in ~30 seconds, before any
+expensive work begins.
+
+**Skip condition:** If `dk_connect` above reported 0 files (greenfield repo),
+**skip the smoke test**. A greenfield repo has no base to merge against, and
+the first generator's merge exercises `dk_merge` for real — the smoke test
+would just duplicate that work without adding signal.
+
+**Skip condition (recency):** If a prior preflight smoke test succeeded in the
+last 5 minutes (same orchestrator session, in-memory flag), skip — the
+platform state has not plausibly changed.
+
+**Budget:** the smoke test must complete in under 3 minutes total. Treat
+anything slower as a FAIL (error class: `timeout`).
+
+**How to run:** dispatch a single sub-agent to perform a sentinel merge
+round-trip. **The orchestrator never touches dkod tools directly** — this is
+a sub-agent responsibility even though it is cheap.
+
+```
+Agent(
+  subagent_type: "general-purpose",
+  model: <generator model from active profile>,
+  effort: "low",
+  prompt: <<~PROMPT,
+    Pre-flight merge smoke test for the dkod harness.
+
+    Your job: validate that the dkod merge pipeline is healthy BEFORE the
+    harness dispatches its expensive generators. Use ONLY these dkod MCP
+    tools: dk_connect, dk_file_write, dk_submit, dk_approve, dk_merge,
+    dk_close. Pass session_id on every call after dk_connect.
+
+    Steps (execute in order; stop and report FAIL at the first error):
+
+    1. dk_connect(codebase: "<owner/repo>",
+                  agent_name: "preflight-smoke",
+                  intent: "Pre-flight merge smoke test")
+    2. dk_file_write(path: ".dkh/preflight.stamp",
+                     content: "<current UTC ISO-8601 timestamp>\n")
+    3. dk_submit(intent: "Pre-flight merge smoke test <timestamp>")
+    4. dk_approve(changeset_id)
+       If local review returns severity:"error" on a single-line timestamp
+       file, something is off — report FAIL with error class
+       `unexpected_review_error`.
+    5. dk_merge(changeset_id,
+                message: "chore: pre-flight merge smoke test <timestamp>")
+    6. dk_close(session_id)
+
+    Report format (pick ONE, exact structure):
+
+    # PASS
+    Pre-flight merge smoke test PASSED.
+    Merged commit: <hash>
+    Elapsed: <seconds>
+
+    # FAIL
+    Pre-flight merge smoke test FAILED.
+    Stage: <connect | write | submit | approve | merge>
+    Error class: <db_schema_error | http_5xx | session_evicted | malformed_response | unexpected_review_error | timeout | unknown>
+    Error message: <raw error>
+
+    Do NOT retry. Do NOT attempt recovery. Return the FAIL report so the
+    orchestrator can abort before dispatching any planner or generators.
+  PROMPT,
+  description: "Pre-flight merge smoke test",
+  name: "preflight-smoke"
+)
+```
+
+**Interpret the result:**
+
+- **PASS** → record the timestamp in an in-memory flag (for the recency skip
+  above), log `preflight_merge: ok (elapsed=<s>s)`, proceed to Tool Detection.
+- **FAIL** → **abort the run**. Output, each line standalone:
+  ```
+  ⛔ Pre-flight merge smoke test failed.
+  Stage: <stage>
+  Error class: <class>
+  Error message: <message>
+
+  The dkod merge pipeline is unhealthy. Aborting before dispatching
+  generators to avoid wasting model budget against a broken platform.
+  Retry `/dkh` once the platform is confirmed healthy.
+  ```
+  Do NOT write a halt manifest (no approved changesets exist yet; there is
+  nothing to preserve). Do NOT proceed to Phase 1. Exit the run.
+
+**Why this does not contradict "orchestrator never writes code":** the sub-agent
+writes a single timestamp file via `dk_file_write` — that goes through dkod's
+session isolation like any other write, just with a trivial payload. The
+orchestrator does not touch `dk_file_write` itself.
+
 ### Tool Detection — Run Once During PRE-FLIGHT
 
 Detect preferred tools and store flags for all subsequent agent dispatches:

--- a/skills/dkh/agents/orchestrator.md
+++ b/skills/dkh/agents/orchestrator.md
@@ -185,7 +185,7 @@ anything slower as a FAIL (error class: `timeout`).
 round-trip. **The orchestrator never touches dkod tools directly** — this is
 a sub-agent responsibility even though it is cheap.
 
-```
+```text
 Agent(
   subagent_type: "general-purpose",
   model: <generator model from active profile>,
@@ -244,7 +244,7 @@ Agent(
 - **PASS** → record the timestamp in an in-memory flag (for the recency skip
   above), log `preflight_merge: ok (elapsed=<s>s)`, proceed to Tool Detection.
 - **FAIL** → **abort the run**. Output, each line standalone:
-  ```
+  ```text
   ⛔ Pre-flight merge smoke test failed.
   Stage: <stage>
   Error class: <class>

--- a/skills/dkh/agents/orchestrator.md
+++ b/skills/dkh/agents/orchestrator.md
@@ -195,8 +195,8 @@ Agent(
 
     Your job: validate that the dkod merge pipeline is healthy BEFORE the
     harness dispatches its expensive generators. Use ONLY these dkod MCP
-    tools: dk_connect, dk_file_write, dk_submit, dk_approve, dk_merge,
-    dk_close. Pass session_id on every call after dk_connect.
+    tools: dk_connect, dk_file_write, dk_submit, dk_verify, dk_approve,
+    dk_merge, dk_close. Pass session_id on every call after dk_connect.
 
     Steps (execute in order; stop and report FAIL at the first error):
 
@@ -206,13 +206,17 @@ Agent(
     2. dk_file_write(path: ".dkh/preflight.stamp",
                      content: "<current UTC ISO-8601 timestamp>\n")
     3. dk_submit(intent: "Pre-flight merge smoke test <timestamp>")
-    4. dk_approve(changeset_id)
+    4. dk_verify(changeset_id)
+       Exercises lint/type-check/test/semantic on the changeset. A timestamp
+       file has no symbols to verify, so this should pass trivially; a FAIL
+       here signals a platform issue in the verify path.
+    5. dk_approve(changeset_id)
        If local review returns severity:"error" on a single-line timestamp
        file, something is off — report FAIL with error class
        `unexpected_review_error`.
-    5. dk_merge(changeset_id,
+    6. dk_merge(changeset_id,
                 message: "chore: pre-flight merge smoke test <timestamp>")
-    6. dk_close(session_id)
+    7. dk_close(session_id)
 
     Report format (pick ONE, exact structure):
 
@@ -223,7 +227,7 @@ Agent(
 
     # FAIL
     Pre-flight merge smoke test FAILED.
-    Stage: <connect | write | submit | approve | merge>
+    Stage: <connect | write | submit | verify | approve | merge>
     Error class: <db_schema_error | http_5xx | session_evicted | malformed_response | unexpected_review_error | timeout | unknown>
     Error message: <raw error>
 


### PR DESCRIPTION
## Why

A recent `/dkh` run burned 7 parallel Opus generators (~30 min of model budget) before the first `dk_merge` call surfaced a platform-side DB schema regression (`column "parent_changeset_id" does not exist`). The failure was only discoverable at merge time — by which point every generator had already done its work for nothing.

This PR adds a pre-flight merge smoke test: a ~30-second round-trip through the dkod merge pipeline, dispatched as a single sub-agent, that catches this class of platform outage **before** the planner or any generators run.

## What this PR adds — `orchestrator.md`

New section "Pre-Flight Merge Smoke Test" inserted after the existing PRE-FLIGHT bulk-close and before Tool Detection.

The smoke test:
1. Runs as a sub-agent (orchestrator never calls dkod tools directly — constraint preserved).
2. Writes a timestamp to `.dkh/preflight.stamp`, submits, approves, merges, closes. One-byte-ish payload.
3. Returns PASS or a structured FAIL report with stage, error class, and raw message.
4. Budget: 3 minutes; slower counts as FAIL (`error_class: timeout`).

Skip conditions:
- **Greenfield repo** (0 files at `dk_connect`): the first generator's merge is already a real canary, so the smoke test would duplicate work without adding signal.
- **Recency** (≤5 min since last PASS in the same orchestrator session): platform state has not plausibly changed.

On FAIL: the orchestrator aborts before Phase 1. No halt manifest is written (no approved changesets exist yet to preserve).

## Why docs-only

Same as PR #85 — the harness is a skill; its "code" is the prompt text. CodeRabbit does not meaningfully review markdown. Greptile will review.

## Relationship to PR #85 (platform_halt circuit-breaker)

These two PRs are **independent and additive**. Either can merge first:

- PR #85 handles mid-run merge failures that slip past the smoke test (e.g., platform breaks between smoke test and the first generator's merge 30 minutes later, or a greenfield repo where we skip the smoke test).
- This PR prevents the cost of even starting a run against an already-broken platform.

Together they make the harness's response to platform outages: detect early (smoke test), then contain the blast radius if something breaks later (circuit-breaker + halt manifest).

## Test plan

- [ ] Greptile review passes at 5/5
- [ ] Next `/dkh` run on an existing repo: verify a preflight smoke-test sub-agent is dispatched, produces a PASS report, and the orchestrator logs the elapsed time before proceeding to Tool Detection
- [ ] Run on a greenfield repo: verify the smoke test is skipped with the correct log line
- [ ] Simulate a FAIL (e.g., temporarily revoke DKOD_API_KEY): verify orchestrator aborts before Phase 1, no halt manifest is written
- [ ] Merge commits from successful smoke tests land in `.dkh/preflight.stamp` without polluting other paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a one-time pre-flight "Merge Smoke Test" that runs before planning to exercise a full merge round-trip; it skips on greenfield runs or if a prior smoke test succeeded within 5 minutes. The test has a strict ~3-minute timeout and will abort the run immediately on failure, preventing planning.

* **Documentation**
  * Updated orchestrator docs to describe the new pre-flight smoke test, skip conditions, timeout behavior, and abort semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->